### PR TITLE
feat: add settings page displaying contract ID, network, and threshol…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,11 +2,12 @@ import { useState } from "react";
 import { CreateProposalModal } from "./components/CreateProposalModal";
 import { DashboardPage } from "./pages/DashboardPage";
 import { HistoryPage } from "./pages/HistoryPage";
+import { SettingsPage } from "./pages/SettingsPage";
 import { useContract } from "./hooks/useContract";
 import { useWallet } from "./hooks/useWallet";
 import { approveProposal, executeProposal } from "./lib/submit";
 
-type Page = "dashboard" | "history";
+type Page = "dashboard" | "history" | "settings";
 
 export default function App() {
   const [page, setPage] = useState<Page>("dashboard");
@@ -66,7 +67,7 @@ export default function App() {
           </div>
 
           <nav className="flex items-center gap-1">
-            {(["dashboard", "history"] as Page[]).map((navPage) => (
+            {(["dashboard", "history", "settings"] as Page[]).map((navPage) => (
               <button
                 key={navPage}
                 type="button"
@@ -146,11 +147,13 @@ export default function App() {
             onExecute={handleExecute}
             onCreateProposal={() => setShowCreate(true)}
           />
-        ) : (
+        ) : page === "history" ? (
           <HistoryPage
             historyProposals={historyProposals}
             onApprove={handleApprove}
           />
+        ) : (
+          <SettingsPage stats={stats} />
         )}
       </main>
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,39 @@
+import type { DashboardStat } from "../types/accord";
+
+type SettingsPageProps = {
+  stats: DashboardStat[];
+};
+
+export function SettingsPage({ stats }: SettingsPageProps) {
+  const contractId = import.meta.env.VITE_CONTRACT_ADDRESS ?? "Unknown";
+  const network = import.meta.env.VITE_NETWORK_PASSPHRASE ?? "Unknown";
+  const threshold = stats.find((stat) => stat.label === "Threshold")?.value ?? "Unknown";
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Settings</h1>
+        <p className="mt-2 text-sm text-zinc-400">
+          Reference information for your deployed contract and connected network.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-5">
+          <div className="text-sm text-zinc-500 mb-2">Contract ID</div>
+          <div className="font-mono text-sm text-zinc-100 break-all">{contractId}</div>
+        </div>
+
+        <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-5">
+          <div className="text-sm text-zinc-500 mb-2">Network</div>
+          <div className="text-sm text-zinc-100">{network}</div>
+        </div>
+
+        <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-5">
+          <div className="text-sm text-zinc-500 mb-2">Threshold</div>
+          <div className="text-sm text-zinc-100">{threshold}</div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #24 

## PR description for the Settings page fix

**Title**
Add `Settings` tab with contract address, network, and threshold info

**Description**
This adds a new `Settings` page to the frontend and exposes it through the top-level navigation.

- Added SettingsPage.tsx
- Extended App.tsx page routing to include `settings`
- Added `settings` to the nav tabs
- Rendered `<SettingsPage stats={stats} />` when the current page is `settings`
- `SettingsPage` reads:
  - `VITE_CONTRACT_ADDRESS` from `import.meta.env`
  - `VITE_NETWORK_PASSPHRASE` from `import.meta.env`
  - `Threshold` from the existing `stats` prop

**Why**
Owners need a single place in the UI to verify the deployed contract address, connected Stellar network, and required signing threshold.

**Verification**
- `cd frontend && npm run build`
- Open the app
- Confirm a new `Settings` tab appears alongside `Dashboard` and `History`
- Click `Settings` and verify it shows:
  - `Contract ID`
  - `Network`
  - `Threshold`

**Notes**
- The threshold value matches the existing dashboard stat card format (e.g. `2 of 3`)
- No other pages or flows were changed beyond navigation and the new page render path