### PR TITLE
Add status filter tabs to history page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,9 +23,7 @@ export default function App() {
     ["pending", "ready"].includes(p.status)
   );
 
-  const historyProposals = proposals.filter((p) =>
-    ["executed", "expired", "revoked"].includes(p.status)
-  );
+ 
 
   async function withTx(fn: () => Promise<void>) {
     if (!wallet.address) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -159,13 +159,12 @@ export default function App() {
             onCreateProposal={() => setShowCreate(true)}
           />
         ) : page === "history" ? (
-          <HistoryPage
-            historyProposals={historyProposals}
-            onApprove={handleApprove}
-          />
+          <HistoryPage proposals={proposals} onApprove={handleApprove} />
         ) : (
+          <>
           <NotFoundPage onGoHome={handleGoHome} />
           <SettingsPage stats={stats} />
+          </>
         )}
       </main>
 

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -1,25 +1,61 @@
-import type { Proposal } from "../types/accord";
+import { useState } from "react";
+import type { Proposal, ProposalStatus } from "../types/accord";
 import { ProposalCard } from "../components/ProposalCard";
 
+type Filter = "all" | ProposalStatus;
+
+const TABS: { key: Filter; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "pending", label: "Pending" },
+  { key: "ready", label: "Ready" },
+  { key: "executed", label: "Executed" },
+  { key: "expired", label: "Expired" },
+  { key: "revoked", label: "Revoked" },
+];
+
 export function HistoryPage({
-  historyProposals,
+  proposals,
   onApprove,
 }: {
-  historyProposals: Proposal[];
+  proposals: Proposal[];
   onApprove: (id: number) => void;
 }) {
+  const [activeTab, setActiveTab] = useState<Filter>("all");
   const noop = () => {};
+
+  const filteredProposals =
+    activeTab === "all"
+      ? proposals
+      : proposals.filter((p) => p.status === activeTab);
 
   return (
     <>
-      <h2 className="font-semibold mb-4">Proposal History</h2>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="font-semibold">Proposal History</h2>
+        <div className="flex items-center gap-1 bg-zinc-900 border border-zinc-800 p-1 rounded-lg">
+          {TABS.map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setActiveTab(tab.key)}
+              className={`text-xs px-3 py-1 rounded-md capitalize transition-colors ${
+                activeTab === tab.key
+                  ? "bg-zinc-700 text-white"
+                  : "text-zinc-400 hover:text-zinc-200"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
       <div className="space-y-3">
-        {historyProposals.length === 0 ? (
+        {filteredProposals.length === 0 ? (
           <p className="text-zinc-600 text-sm py-8 text-center">
-            No completed proposals yet
+            No {activeTab === "all" ? "" : `${activeTab} `}proposals found
           </p>
         ) : (
-          historyProposals.map((proposal) => (
+          filteredProposals.map((proposal) => (
             <ProposalCard
               key={proposal.id}
               proposal={proposal}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "AccordProtocol",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
### Feat: Add Status Filters to History Page
closes #32 
**Summary**

This pull request enhances the `HistoryPage` by introducing a tab-based filtering system. Users can now filter the list of proposals by their status ("pending", "ready", "executed", "expired", "revoked") or view all proposals at once. This makes it much easier to navigate and find specific proposals in a long history.

**Background**

Previously, the `HistoryPage` displayed a static, pre-filtered list of historical proposals (`executed`, `expired`, `revoked`). There was no way for a user to view active proposals (`pending`, `ready`) on this page or to isolate proposals of a specific status. This change decouples the filtering logic from the parent `App` component and moves it into the `HistoryPage`, giving the user direct control over the view.

**Changes**

*   **`App.tsx`**:
    *   The `HistoryPage` component is now passed the complete, unfiltered `proposals` array instead of the pre-filtered `historyProposals` subset.

*   **`pages/HistoryPage.tsx`**:
    *   Introduced local state (`activeTab`) to manage the currently selected filter, defaulting to "all".
    *   Added a UI component with tabs for "All" and each of the five proposal statuses.
    *   The list of proposals is now filtered client-side based on the `activeTab` state before rendering.
    *   The empty-state message has been updated to be dynamic, reflecting the active filter (e.g., "No pending proposals found").

This implementation makes the `HistoryPage` a more powerful and useful tool for reviewing proposal activity.
