### PR TITLE
Add tests for revoke then re-approve and has_approved correctness

### DIFF
--- a/contracts/accord/src/test.rs
+++ b/contracts/accord/src/test.rs
@@ -423,6 +423,43 @@ fn revoke_rejects_when_not_previously_approved() {
     );
 }
 
+// ─── Revoke → Re-approve ──────────────────────────────────────────────────────
+
+#[test]
+fn revoke_allows_reapprove() {
+    let (env, client, owner_a, _, _, _, token_client) = setup(2);
+    let id = client.create_proposal(
+        &owner_a,
+        &Address::generate(&env),
+        &1_000_000_i128,
+        &token_client.address,
+        &str(&env, "Pay"),
+        &DEADLINE,
+    );
+    client.approve(&owner_a, &id);
+    client.revoke(&owner_a, &id);
+    // Re-approve — should succeed
+    client.approve(&owner_a, &id);
+    assert_eq!(client.get_proposal(&id).approvals, 1);
+}
+
+#[test]
+fn has_approved_returns_false_after_revoke() {
+    let (env, client, owner_a, _, _, _, token_client) = setup(2);
+    let id = client.create_proposal(
+        &owner_a,
+        &Address::generate(&env),
+        &1_000_000_i128,
+        &token_client.address,
+        &str(&env, "Pay"),
+        &DEADLINE,
+    );
+    client.approve(&owner_a, &id);
+    assert!(client.has_approved(&id, &owner_a));
+    client.revoke(&owner_a, &id);
+    assert!(!client.has_approved(&id, &owner_a));
+}
+
 // ─── Execute ─────────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Description
This PR adds missing test coverage for approval state transitions in the AccordProtocol smart contract.

It verifies correct behavior for the revoke → re-approve lifecycle and ensures that `has_approved` accurately reflects state changes after a revoke operation.

---

## Linked Issue
Closes #49

---

## What Was Added

Two new tests were implemented in `contracts/accord/src/test.rs`:

### 1. revoke_allows_reapprove
- Creates a proposal using the existing setup helper
- Approves the proposal for a single owner
- Revokes the approval for the same owner
- Re-approves the proposal again
- Verifies:
  - Second approval succeeds without error
  - Final approval count returns to 1

---

### 2. has_approved_returns_false_after_revoke
- Creates a proposal and approves it
- Asserts `has_approved(owner, proposal) == true`
- Revokes approval
- Asserts `has_approved(owner, proposal) == false`

---

## Behavioral Coverage

This PR ensures:
- Approval state can be re-established after revoke
- Storage correctly updates per-owner approval state
- Read function `has_approved` remains consistent with internal state
- No regression in existing approval/revoke logic

---

## PR Checklist
- [x] I have run `cargo test` locally and all tests pass.
- [x] I have not modified production contract logic.
- [x] I only added test coverage.
- [x] All new tests follow existing naming conventions.
- [x] No existing tests were broken.