### PR TITLE
Add: I added browser push notification when the connected wallet has a pending approval

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,17 +7,10 @@ import { SettingsPage } from "./pages/SettingsPage";
 import { OwnersPage } from "./pages/OwnersPage";
 import { useContract } from "./hooks/useContract";
 import { useWallet } from "./hooks/useWallet";
-<<<<<<< feature/wallet-ui-and-token-validation-23-26-30-34
-import { approveProposal, executeProposal } from "./lib/submit";
-
-type Page = "dashboard" | "history" | "settings" | "owners";
-import { ProposalCardSkeleton } from "./components/ProposalCardSkeleton";
-=======
-// CHANGE 1: Import revokeProposal from submit.ts
+import { useNotifications } from "./hooks/useNotifications";
 import { approveProposal, executeProposal, revokeProposal } from "./lib/submit";
 
-type Page = "dashboard" | "history" | "settings";
->>>>>>> main
+type Page = "dashboard" | "history" | "settings" | "owners";
 
 export default function App() {
   const [page, setPage] = useState<Page>("dashboard");
@@ -26,7 +19,6 @@ export default function App() {
   const [txPending, setTxPending] = useState(false);
 
   const wallet = useWallet();
-<<<<<<< feature/wallet-ui-and-token-validation-23-26-30-34
   const [copied, setCopied] = useState(false);
 
   function handleCopy() {
@@ -39,13 +31,11 @@ export default function App() {
       // ignore clipboard errors
     }
   }
-  const navigate = useNavigate();
-  const location = useLocation();
-  const currentPath = location.pathname;
-=======
-  // CHANGE 2: Pass wallet.address into useContract so it can fetch userHasApproved
+
   const { proposals, owners, stats, loading, error, refresh } = useContract(wallet.address);
->>>>>>> main
+
+  // Wire push notifications for proposals pending approval
+  useNotifications(wallet.address, proposals);
 
   const activeProposals = proposals.filter((p) =>
     ["pending", "ready"].includes(p.status)
@@ -76,7 +66,6 @@ export default function App() {
   const handleExecute = (id: number) =>
     withTx(() => executeProposal(wallet.address!, id));
 
-  // CHANGE 3: Create the handleRevoke function
   const handleRevoke = (id: number) =>
     withTx(() => revokeProposal(wallet.address!, id));
 
@@ -91,7 +80,6 @@ export default function App() {
   return (
     <div className="min-h-screen bg-zinc-950 text-white">
       <header className="border-b border-zinc-800 px-6 py-4">
-        {/* ... (Keep your existing header code exactly the same) ... */}
         <div className="max-w-4xl mx-auto flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="w-7 h-7 rounded-lg bg-emerald-500 flex items-center justify-center text-xs font-bold text-black">
@@ -104,26 +92,11 @@ export default function App() {
           </div>
 
           <nav className="flex items-center gap-1">
-<<<<<<< feature/wallet-ui-and-token-validation-23-26-30-34
             {(["dashboard", "history", "owners", "settings"] as Page[]).map((navPage) => (
-=======
-            {(["dashboard", "history", "settings"] as Page[]).map((navPage) => (
->>>>>>> main
               <button
                 key={navPage}
                 type="button"
                 onClick={() => setPage(navPage)}
-<<<<<<< feature/wallet-ui-and-token-validation-23-26-30-34
-            {[
-              { label: "dashboard", to: "/" },
-              { label: "history", to: "/history" },
-              { label: "settings", to: "/settings" },
-            ].map(({ label, to }) => (
-              <Link
-                key={label}
-                to={to}
-=======
->>>>>>> main
                 className={`text-sm px-3 py-1.5 rounded-lg capitalize transition-colors ${
                   page === navPage
                     ? "bg-zinc-800 text-white"
@@ -220,31 +193,21 @@ export default function App() {
             walletAddress={wallet.address}
             onApprove={handleApprove}
             onExecute={handleExecute}
-            onRevoke={handleRevoke} /* CHANGE 4: Pass the handleRevoke function down to the Dashboard */
+            onRevoke={handleRevoke}
             onCreateProposal={() => setShowCreate(true)}
           />
         ) : page === "history" ? (
           <HistoryPage proposals={proposals} onApprove={handleApprove} />
-<<<<<<< feature/wallet-ui-and-token-validation-23-26-30-34
         ) : page === "owners" ? (
           <OwnersPage
             owners={owners}
             threshold={parseInt(stats.find((s) => s.label === "Threshold")?.value.split(" ")[0] || "0")}
             totalOwners={owners.length}
           />
-          <HistoryPage
-            historyProposals={historyProposals}
-            onApprove={handleApprove}
-          />
         ) : page === "settings" ? (
           <SettingsPage stats={stats} />
-=======
->>>>>>> main
         ) : (
-          <>
           <NotFoundPage onGoHome={handleGoHome} />
-          <SettingsPage stats={stats} />
-          </>
         )}
       </main>
 

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from "react";
+import type { Proposal } from "../types/accord";
+
+export function useNotifications(
+  walletAddress: string | null,
+  proposals: Proposal[]
+) {
+  const [permission, setPermission] = useState<NotificationPermission>("default");
+  const notifiedIds = useRef<Set<number>>(new Set());
+  const lastWalletAddress = useRef<string | null>(null);
+
+  // Request/Check permission on mount
+  useEffect(() => {
+    if (typeof window !== "undefined" && "Notification" in window) {
+      if (Notification.permission === "default") {
+        Notification.requestPermission().then((res) => {
+          setPermission(res);
+        });
+      } else {
+        setPermission(Notification.permission);
+      }
+    }
+  }, []);
+
+  // Clear notified IDs if the connected wallet address changes
+  useEffect(() => {
+    if (walletAddress !== lastWalletAddress.current) {
+      notifiedIds.current.clear();
+      lastWalletAddress.current = walletAddress;
+    }
+  }, [walletAddress]);
+
+  // Monitor proposals and notify if new pending ones appear
+  useEffect(() => {
+    if (!walletAddress || permission !== "granted" || proposals.length === 0) {
+      return;
+    }
+
+    const pendingProposals = proposals.filter((p) => p.status === "pending");
+    if (pendingProposals.length === 0) {
+      return;
+    }
+
+    // Check if there are any new pending proposals that haven't been notified yet
+    const newPendingProposals = pendingProposals.filter(
+      (p) => !notifiedIds.current.has(p.id)
+    );
+
+    if (newPendingProposals.length > 0) {
+      // Add all current pending proposal IDs to the notified set to avoid duplicates
+      pendingProposals.forEach((p) => notifiedIds.current.add(p.id));
+
+      const title = "Pending Approval";
+      const body = `You have ${pendingProposals.length} proposal${
+        pendingProposals.length === 1 ? "" : "s"
+      } waiting for approval.`;
+
+      try {
+        new Notification(title, { body });
+      } catch (err) {
+        console.error("Failed to trigger notification", err);
+      }
+    }
+  }, [proposals, walletAddress, permission]);
+}


### PR DESCRIPTION
closes #67 

This pull request implements native browser push notifications to alert multisig owners when new proposals are pending their approval. With this change, owners who keep the application open in a background tab will receive an OS-level notification whenever a new proposal enters the pending state.

To support this, we created a new custom hook, useNotifications, which handles checking and requesting browser notification permissions on mount. The hook monitors the proposals array and triggers a notification only when it detects new pending proposals. Crucially, the hook maintains an internal reference set of notified proposal IDs, ensuring that once a proposal has triggered an alert, it will not produce duplicate notifications during subsequent poll cycles. Additionally, if the connected wallet address changes, the set of notified IDs is reset so that the new account can be properly alerted of any pending proposals.

As part of integrating this hook, we also resolved existing git merge conflicts in App.tsx. We consolidated the routing pages (adding the "owners" page tab back), cleaned up duplicate maps and syntax errors in the header navigation, and properly wired up the useNotifications hook to take the connected wallet's address and proposals list directly.