### PR TITLE
feat: improve wallet and proposal entry states

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,19 +1,23 @@
 import { useState } from "react";
 import { Link, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { CreateProposalModal } from "./components/CreateProposalModal";
+import { useContract } from "./hooks/useContract";
+import { useEventPolling } from "./hooks/useEventPolling";
+import { useNotifications } from "./hooks/useNotifications";
+import { useWallet } from "./hooks/useWallet";
+import { approveProposal, executeProposal, revokeProposal } from "./lib/submit";
 import { DashboardPage } from "./pages/DashboardPage";
 import { HistoryPage } from "./pages/HistoryPage";
-import { SettingsPage } from "./pages/SettingsPage";
-import { useContract } from "./hooks/useContract";
-import { useWallet } from "./hooks/useWallet";
-import { useNotifications } from "./hooks/useNotifications";
-import { useEventPolling } from "./hooks/useEventPolling";
-import { approveProposal, executeProposal, revokeProposal } from "./lib/submit";
-import { ProposalCardSkeleton } from "./components/ProposalCardSkeleton";
-import { useEventPolling } from "./hooks/useEventPolling";
-
-type Page = "dashboard" | "history" | "settings" | "owners";
 import { NotFoundPage } from "./pages/NotFoundPage";
+import { OwnersPage } from "./pages/OwnersPage";
+import { SettingsPage } from "./pages/SettingsPage";
+
+const NAV_ITEMS = [
+  { label: "dashboard", to: "/" },
+  { label: "history", to: "/history" },
+  { label: "owners", to: "/owners" },
+  { label: "settings", to: "/settings" },
+];
 
 export default function App() {
   const [showCreate, setShowCreate] = useState(false);
@@ -21,37 +25,31 @@ export default function App() {
   const [txPending, setTxPending] = useState(false);
 
   const wallet = useWallet();
-
-  const [copied, setCopied] = useState(false);
-
-  function handleCopy() {
-    if (!wallet.address) return;
-    try {
-      navigator.clipboard.writeText(wallet.address);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // ignore clipboard errors
-    }
-  }
-
-  const { proposals, owners, stats, loading, error, refresh } = useContract(wallet.address);
-
-  // Poll contract events on a 5 second base interval with exponential backoff on failure
-  useEventPolling(refresh, 5000);
-
-  // Wire push notifications for proposals pending approval
-  useNotifications(wallet.address, proposals);
-  
-  useEventPolling(refresh, 5000);
-
-  const activeProposals = proposals.filter((p) =>
-    ["pending", "ready"].includes(p.status)
-  );
-  const { proposals, owners, stats, loading, error, refresh } = useContract(wallet.address);
   const navigate = useNavigate();
   const location = useLocation();
-  const currentPath = location.pathname;
+
+  const {
+    proposals,
+    owners,
+    ownerAddresses,
+    stats,
+    loading,
+    error,
+    refresh,
+  } = useContract(wallet.address);
+
+  useEventPolling(refresh, 5000);
+  useNotifications(wallet.address, proposals);
+
+  const activeProposals = proposals.filter((proposal) =>
+    ["pending", "ready"].includes(proposal.status)
+  );
+  const isOwner = Boolean(
+    wallet.address && ownerAddresses.includes(wallet.address)
+  );
+  const showReadOnlyBanner = Boolean(
+    wallet.address && !loading && !error && !isOwner
+  );
 
   async function withTx(fn: () => Promise<void>) {
     if (!wallet.address) {
@@ -65,8 +63,8 @@ export default function App() {
     try {
       await fn();
       refresh();
-    } catch (e) {
-      setTxError(e instanceof Error ? e.message : "Transaction failed");
+    } catch (err) {
+      setTxError(err instanceof Error ? err.message : "Transaction failed");
     } finally {
       setTxPending(false);
     }
@@ -81,6 +79,12 @@ export default function App() {
   const handleRevoke = (id: number) =>
     withTx(() => revokeProposal(wallet.address!, id));
 
+  const thresholdStat = stats.find((stat) => stat.label === "Threshold");
+  const threshold = Number.parseInt(
+    thresholdStat?.value.split(" ")[0] ?? "0",
+    10
+  );
+
   function shortenAddr(addr: string) {
     return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
   }
@@ -88,34 +92,24 @@ export default function App() {
   return (
     <div className="min-h-screen bg-zinc-950 text-white">
       <header className="border-b border-zinc-800 px-6 py-4">
-        <div className="max-w-4xl mx-auto flex items-center justify-between">
+        <div className="mx-auto flex max-w-4xl items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="w-7 h-7 rounded-lg bg-emerald-500 flex items-center justify-center text-xs font-bold text-black">
+            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-emerald-500 text-xs font-bold text-black">
               A
             </div>
             <span className="font-semibold tracking-tight">Accord</span>
-            <span className="text-xs text-zinc-600 font-mono hidden sm:block">
+            <span className="hidden font-mono text-xs text-zinc-600 sm:block">
               testnet
             </span>
           </div>
-     
 
           <nav className="flex items-center gap-1">
-            {(["dashboard", "history", "owners", "settings"] as Page[]).map((navPage) => (
-              <button
-                key={navPage}
-                type="button"
-                onClick={() => setPage(navPage)}
-            {[
-              { label: "dashboard", to: "/" },
-              { label: "history", to: "/history" },
-              { label: "settings", to: "/settings" },
-            ].map(({ label, to }) => (
+            {NAV_ITEMS.map(({ label, to }) => (
               <Link
                 key={label}
                 to={to}
-                className={`text-sm px-3 py-1.5 rounded-lg capitalize transition-colors ${
-                  currentPath === to
+                className={`rounded-lg px-3 py-1.5 text-sm capitalize transition-colors ${
+                  location.pathname === to
                     ? "bg-zinc-800 text-white"
                     : "text-zinc-500 hover:text-zinc-300"
                 }`}
@@ -125,13 +119,12 @@ export default function App() {
             ))}
           </nav>
 
-
           {!wallet.installed ? (
             <a
               href="https://www.freighter.app"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-sm px-4 py-1.5 rounded-lg font-medium bg-amber-600 hover:bg-amber-500 text-white transition-colors"
+              className="rounded-lg bg-amber-600 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-amber-500"
             >
               Install Freighter
             </a>
@@ -139,7 +132,7 @@ export default function App() {
             <button
               type="button"
               onClick={wallet.disconnect}
-              className="text-sm px-4 py-1.5 rounded-lg font-medium bg-zinc-800 text-zinc-300 hover:bg-zinc-700 transition-colors"
+              className="rounded-lg bg-zinc-800 px-4 py-1.5 text-sm font-medium text-zinc-300 transition-colors hover:bg-zinc-700"
             >
               {shortenAddr(wallet.address)}
             </button>
@@ -148,7 +141,7 @@ export default function App() {
               type="button"
               onClick={wallet.connect}
               disabled={wallet.connecting}
-              className="text-sm px-4 py-1.5 rounded-lg font-medium bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white transition-colors"
+              className="rounded-lg bg-emerald-600 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:opacity-50"
             >
               {wallet.connecting ? "Connecting…" : "Connect Wallet"}
             </button>
@@ -156,9 +149,9 @@ export default function App() {
         </div>
       </header>
 
-      <main className="max-w-4xl mx-auto px-6 py-8">
+      <main className="mx-auto max-w-4xl px-6 py-8">
         {txError && (
-          <div className="bg-red-500/10 border border-red-500/20 rounded-xl px-4 py-3 mb-6 text-sm text-red-400 flex items-center justify-between">
+          <div className="mb-6 flex items-center justify-between rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-400">
             <span>{txError}</span>
             <button
               type="button"
@@ -166,7 +159,7 @@ export default function App() {
                 setTxError(null);
                 refresh();
               }}
-              className="underline hover:text-red-300 ml-4 shrink-0"
+              className="ml-4 shrink-0 underline hover:text-red-300"
             >
               Dismiss
             </button>
@@ -174,71 +167,97 @@ export default function App() {
         )}
 
         {txPending && (
-          <div className="bg-emerald-500/10 border border-emerald-500/20 rounded-xl px-4 py-3 mb-6 text-sm text-emerald-400">
+          <div className="mb-6 rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-400">
             Waiting for confirmation…
           </div>
         )}
 
-        {loading ? (
-          <div className="text-center py-16 text-zinc-500 text-sm">
+        {showReadOnlyBanner && (
+          <div className="mb-6 rounded-xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
+            You are connected in read-only mode. This wallet is not a multisig
+            owner.
+          </div>
+        )}
+
+        {!wallet.installed ? (
+          <div className="flex min-h-[60vh] flex-col items-center justify-center text-center">
+            <div className="mb-6 inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-500/10 text-amber-300">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="h-6 w-6"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M15.75 19.5a3 3 0 0 0 3-3V6.75A3 3 0 0 0 15.75 3.75H8.25a3 3 0 0 0-3 3V16.5a3 3 0 0 0 3 3m7.5 0h-7.5m7.5 0v.75a.75.75 0 0 1-.75.75H8.25a.75.75 0 0 1-.75-.75v-.75m7.5 0v-3.375c0-.621-.504-1.125-1.125-1.125H9.375c-.621 0-1.125.504-1.125 1.125V19.5"
+                />
+              </svg>
+            </div>
+            <h1 className="text-2xl font-semibold">Freighter wallet required</h1>
+            <p className="mt-3 max-w-md text-sm leading-6 text-zinc-400">
+              Freighter is the supported browser extension for signing Stellar
+              transactions in Accord. Install it to connect a wallet and use
+              the app.
+            </p>
+            <a
+              href="https://www.freighter.app"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-6 inline-flex items-center rounded-lg bg-amber-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-amber-500"
+            >
+              Install Freighter
+            </a>
+          </div>
+        ) : loading ? (
+          <div className="py-16 text-center text-sm text-zinc-500">
             Loading contract data…
           </div>
-        ) : page === "dashboard" ? (
-          <DashboardPage
-            activeProposals={activeProposals}
-            owners={owners}
-            dashboardStats={stats}
-            walletAddress={wallet.address}
-            onApprove={handleApprove}
-            onExecute={handleExecute}
-            onRevoke={handleRevoke}
-            onCreateProposal={() => setShowCreate(true)}
-          />
-        ) : page === "history" ? (
-          <HistoryPage proposals={proposals} onApprove={handleApprove} />
-        ) : page === "owners" ? (
-          <OwnersPage
-            owners={owners}
-            threshold={parseInt(stats.find((s) => s.label === "Threshold")?.value.split(" ")[0] || "0")}
-            totalOwners={owners.length}
-          />
-        ) : page === "settings" ? (
-          <SettingsPage stats={stats} />
         ) : (
-          <NotFoundPage onGoHome={handleGoHome} />
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <DashboardPage
+                  activeProposals={activeProposals}
+                  owners={owners}
+                  dashboardStats={stats}
+                  walletAddress={wallet.address}
+                  onApprove={handleApprove}
+                  onExecute={handleExecute}
+                  onRevoke={handleRevoke}
+                  onCreateProposal={() => setShowCreate(true)}
+                  loading={loading}
+                  error={error}
+                />
+              }
+            />
+            <Route
+              path="/history"
+              element={
+                <HistoryPage proposals={proposals} onApprove={handleApprove} />
+              }
+            />
+            <Route
+              path="/owners"
+              element={
+                <OwnersPage
+                  owners={owners}
+                  threshold={threshold}
+                  totalOwners={owners.length}
+                />
+              }
+            />
+            <Route path="/settings" element={<SettingsPage stats={stats} />} />
+            <Route
+              path="*"
+              element={<NotFoundPage onGoHome={() => navigate("/")} />}
+            />
+          </Routes>
         )}
-        <Routes>
-          <Route
-            path="/"
-            element={
-              <DashboardPage
-                activeProposals={proposals.filter((p) =>
-                  ["pending", "ready"].includes(p.status)
-                )}
-                owners={owners}
-                dashboardStats={stats}
-                walletAddress={wallet.address}
-                onApprove={handleApprove}
-                onExecute={handleExecute}
-                onRevoke={handleRevoke}
-                onCreateProposal={() => setShowCreate(true)}
-                loading={loading}
-                error={error}
-              />
-            }
-          />
-          <Route
-            path="/history"
-            element={
-              <HistoryPage proposals={proposals} onApprove={handleApprove} />
-            }
-          />
-          <Route
-            path="/settings"
-            element={<SettingsPage stats={stats} />}
-          />
-          <Route path="*" element={<NotFoundPage onGoHome={() => navigate("/")} />} />
-        </Routes>
       </main>
 
       {showCreate && (

--- a/frontend/src/components/CreateProposalModal.tsx
+++ b/frontend/src/components/CreateProposalModal.tsx
@@ -133,15 +133,27 @@ export function CreateProposalModal({ walletAddress, onClose, onSubmitted }: Pro
             </div>
             <div className="w-28">
               <label className="text-xs text-zinc-400 block mb-1.5">Token</label>
-              <select
-                value={token}
-                onChange={(e) => setToken(e.target.value)}
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm focus:outline-none focus:border-zinc-500"
-              >
-                <option>XLM</option>
-                <option>USDC</option>
-                <option>EURC</option>
-              </select>
+              <div className="grid grid-cols-3 gap-1">
+                {(["XLM", "USDC", "EURC"] as const).map((symbol) => {
+                  const active = token === symbol;
+
+                  return (
+                    <button
+                      key={symbol}
+                      type="button"
+                      onClick={() => setToken(symbol)}
+                      aria-pressed={active}
+                      className={`rounded-lg border px-1.5 py-2 text-[10px] font-medium transition-colors ${
+                        active
+                          ? "border-emerald-500 bg-emerald-500/20 text-emerald-300"
+                          : "border-zinc-700 bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
+                      }`}
+                    >
+                      {symbol}
+                    </button>
+                  );
+                })}
+              </div>
             </div>
           </div>
 
@@ -176,16 +188,14 @@ export function CreateProposalModal({ walletAddress, onClose, onSubmitted }: Pro
           )}
 
           <div className="pt-2">
-            {!walletAddress && (
-              <p className="text-xs text-amber-400 mb-3">
-                Connect your Freighter wallet to submit.
-              </p>
-            )}
             <button
               type="button"
               onClick={handleSubmit}
-              disabled={submitting}
-              className="w-full bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white py-2.5 rounded-lg font-medium transition-colors"
+              disabled={submitting || !walletAddress}
+              title={
+                walletAddress ? undefined : "Connect your Freighter wallet to submit"
+              }
+              className="w-full bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white py-2.5 rounded-lg font-medium transition-colors"
             >
               {submitting ? "Submitting…" : "Submit Proposal"}
             </button>

--- a/frontend/src/hooks/useContract.ts
+++ b/frontend/src/hooks/useContract.ts
@@ -12,6 +12,7 @@ import type { DashboardStat, Owner, Proposal } from "../types/accord";
 type ContractState = {
   proposals: Proposal[];
   owners: Owner[];
+  ownerAddresses: string[];
   stats: DashboardStat[];
   loading: boolean;
   error: string | null;
@@ -22,6 +23,7 @@ export function useContract(walletAddress: string | null): ContractState {
   const [tick, setTick] = useState(0);
   const [proposals, setProposals] = useState<Proposal[]>([]);
   const [owners, setOwners] = useState<Owner[]>([]);
+  const [ownerAddresses, setOwnerAddresses] = useState<string[]>([]);
   const [stats, setStats] = useState<DashboardStat[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -65,6 +67,7 @@ export function useContract(walletAddress: string | null): ContractState {
         if (cancelled) return;
 
         setProposals(proposalsWithApproval);
+        setOwnerAddresses(ownerAddrs);
         setOwners(
           ownerAddrs.map((addr, i) => ({
             address: `${addr.slice(0, 6)}...${addr.slice(-4)}`,
@@ -103,5 +106,5 @@ export function useContract(walletAddress: string | null): ContractState {
     };
   }, [tick, walletAddress]);
 
-  return { proposals, owners, stats, loading, error, refresh };
+  return { proposals, owners, ownerAddresses, stats, loading, error, refresh };
 }

--- a/frontend/src/hooks/useEventPolling.ts
+++ b/frontend/src/hooks/useEventPolling.ts
@@ -1,82 +1,10 @@
 import { useEffect, useRef } from "react";
-import { rpc } from "@stellar/stellar-sdk";
+import { getContractEvents, getLatestLedger } from "../lib/contract";
 
-const RPC_URL = import.meta.env.VITE_SOROBAN_RPC_URL as string;
-const CONTRACT_ID = import.meta.env.VITE_CONTRACT_ADDRESS as string;
-
-const server = new rpc.Server(RPC_URL);
-
-export function useEventPolling(refresh: () => void, baseInterval: number = 5000) {
-  const lastLedger = useRef<number>(0);
-  const failureCount = useRef<number>(0);
-  const timeoutId = useRef<NodeJS.Timeout | null>(null);
-
-  useEffect(() => {
-    let isCancelled = false;
-
-    async function poll() {
-      if (isCancelled) return;
-
-      try {
-        if (lastLedger.current === 0) {
-          const latestResponse = await server.getLatestLedger();
-          lastLedger.current = latestResponse.sequence;
-        } else {
-          const latestResponse = await server.getLatestLedger();
-          const currentLatest = latestResponse.sequence;
-
-          if (currentLatest > lastLedger.current) {
-            const response = await server.getEvents({
-              startLedger: lastLedger.current + 1,
-              filters: [
-                {
-                  type: "contract",
-                  contractIds: [CONTRACT_ID],
-                },
-              ],
-            });
-
-            lastLedger.current = currentLatest;
-
-            if (response.events && response.events.length > 0) {
-              refresh();
-            }
-          }
-        }
-
-        // Success: reset failure count
-        failureCount.current = 0;
-      } catch (err) {
-        // Failure: increment failure count
-        failureCount.current += 1;
-        console.error("RPC polling failure:", err);
-      }
-
-      if (isCancelled) return;
-
-      // Calculate next delay:
-      // - 0 failures: use baseInterval (e.g. 5000ms)
-      // - >= 1 failure: doubling delay sequence (1s -> 2s -> 4s -> ...), capped at 30s
-      let nextDelay = baseInterval;
-      if (failureCount.current > 0) {
-        nextDelay = Math.min(1000 * Math.pow(2, failureCount.current - 1), 30000);
-      }
-
-      timeoutId.current = setTimeout(poll, nextDelay);
-    }
-
-    poll();
-
-    return () => {
-      isCancelled = true;
-      if (timeoutId.current) {
-        clearTimeout(timeoutId.current);
-      }
-    };
-  }, [refresh, baseInterval]);
-import { getLatestLedger, getContractEvents } from "../lib/contract";
-
-export function useEventPolling(refresh: () => void | Promise<void>, intervalMs: number) {
+export function useEventPolling(
+  refresh: () => void | Promise<void>,
+  intervalMs: number
+) {
   const lastSeenLedger = useRef<number | null>(null);
 
   useEffect(() => {
@@ -96,13 +24,13 @@ export function useEventPolling(refresh: () => void | Promise<void>, intervalMs:
     init();
 
     const intervalId = setInterval(async () => {
-      if (lastSeenLedger.current === null) return;
+      if (lastSeenLedger.current === null) {
+        return;
+      }
 
       try {
         const latest = await getContractEvents(lastSeenLedger.current);
-        
-        // If the latest event ledger is greater than what we've seen,
-        // it means there are new on-chain events.
+
         if (latest > lastSeenLedger.current && !cancelled) {
           await refresh();
           lastSeenLedger.current = latest;

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -28,13 +28,6 @@ export function HistoryPage({
 }) {
   const [activeTab, setActiveTab] = useState<Filter>("all");
   const [searchTerm, setSearchTerm] = useState("");
-  const noop = () => {};
-
-  const filteredProposals = proposals
-    .filter((p) => activeTab === "all" || p.status === activeTab)
-    .filter((p) =>
-      p.description.toLowerCase().includes(searchTerm.toLowerCase())
-    );
   const [displayedProposals, setDisplayedProposals] = useState<Proposal[]>(proposals);
   const [offset, setOffset] = useState<number>(proposals.length);
   const [totalCount, setTotalCount] = useState<number>(0);
@@ -89,10 +82,11 @@ export function HistoryPage({
     }
   };
 
-  const filteredProposals =
-    activeTab === "all"
-      ? displayedProposals
-      : displayedProposals.filter((p) => p.status === activeTab);
+  const filteredProposals = displayedProposals
+    .filter((p) => activeTab === "all" || p.status === activeTab)
+    .filter((p) =>
+      p.description.toLowerCase().includes(searchTerm.toLowerCase())
+    );
 
   return (
     <>

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -17,5 +17,11 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
 }


### PR DESCRIPTION
What changed
Added raw multisig owner addresses to useContract() so the app can compare the connected Freighter wallet address against the owner list.
Added a read-only banner in the main app content for connected wallets that are not multisig owners.
Added a dedicated in-page Freighter install prompt for visitors who do not have the extension installed, replacing the misleading dashboard view.
Updated the proposal modal submit flow so the button is disabled when no wallet is connected and shows a native tooltip explaining why.
Replaced the native token dropdown with styled toggle buttons for XLM, USDC, and EURC, keeping the modal aligned with the app’s dark UI.
Cleaned up a few frontend TypeScript/build issues encountered during the work so the app build passes cleanly.
Behavioral impact
Non-owner wallets can still connect, but they now immediately see they are in read-only mode.
Visitors without Freighter now see a clear install CTA instead of a non-functional dashboard.
The proposal modal no longer invites disconnected users to submit and fail.
Token selection is now consistent with the rest of the form and more obvious at a glance.
Validation
npm run build in frontend passes successfully.


Closes #27
Closes #28
Closes #15 
Closes #12