### PR TITLE
Add proposer filter on history page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,11 +6,6 @@ import { useEventPolling } from "./hooks/useEventPolling";
 import { useNotifications } from "./hooks/useNotifications";
 import { useWallet } from "./hooks/useWallet";
 import { approveProposal, executeProposal, revokeProposal } from "./lib/submit";
-import { ProposalCardSkeleton } from "./components/ProposalCardSkeleton";
-
-type Page = "dashboard" | "history" | "settings" | "owners";
-import { NotFoundPage } from "./pages/NotFoundPage";
-import { OwnersPage } from "./pages/OwnersPage";
 import { DashboardPage } from "./pages/DashboardPage";
 import { HistoryPage } from "./pages/HistoryPage";
 import { NotFoundPage } from "./pages/NotFoundPage";
@@ -28,7 +23,6 @@ export default function App() {
   const [showCreate, setShowCreate] = useState(false);
   const [txError, setTxError] = useState<string | null>(null);
   const [txPending, setTxPending] = useState(false);
-  const [page, setPage] = useState<Page>("dashboard");
 
   const wallet = useWallet();
   const navigate = useNavigate();
@@ -56,10 +50,6 @@ export default function App() {
   const showReadOnlyBanner = Boolean(
     wallet.address && !loading && !error && !isOwner
   );
-  // const { proposals, owners, stats, loading, error, refresh } = useContract(wallet.address);
-  const navigate = useNavigate();
-  const location = useLocation();
-  const currentPath = location.pathname;
 
   async function withTx(fn: () => Promise<void>) {
     if (!wallet.address) {
@@ -99,10 +89,6 @@ export default function App() {
     return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
   }
 
-  function handleGoHome() {
-    setPage("dashboard");
-  }
-
   return (
     <div className="min-h-screen bg-zinc-950 text-white">
       <header className="border-b border-zinc-800 px-6 py-4">
@@ -118,19 +104,6 @@ export default function App() {
           </div>
 
           <nav className="flex items-center gap-1">
-            {(["dashboard", "history", "owners", "settings"] as Page[]).map((navPage) => (
-              <button
-                key={navPage}
-                type="button"
-                onClick={() => setPage(navPage)}>
-                  
-                </button>
-            ))}
-            {[
-              { label: "dashboard", to: "/" },
-              { label: "history", to: "/history" },
-              { label: "settings", to: "/settings" },
-            ].map(({ label, to }) => (
             {NAV_ITEMS.map(({ label, to }) => (
               <Link
                 key={label}
@@ -249,29 +222,6 @@ export default function App() {
           <div className="py-16 text-center text-sm text-zinc-500">
             Loading contract data…
           </div>
-        ) : page === "dashboard" ? (
-          <DashboardPage
-            activeProposals={activeProposals}
-            owners={owners}
-            dashboardStats={stats}
-            walletAddress={wallet.address}
-            onApprove={handleApprove}
-            onExecute={handleExecute}
-            onRevoke={handleRevoke}
-            onCreateProposal={() => setShowCreate(true)}
-            error={null}
-            loading
-          />
-        ) : page === "history" ? (
-          <HistoryPage proposals={proposals} onApprove={handleApprove} />
-        ) : page === "owners" ? (
-          <OwnersPage
-            owners={owners}
-            threshold={parseInt(stats.find((s) => s.label === "Threshold")?.value.split(" ")[0] || "0")}
-            totalOwners={owners.length}
-          />
-        ) : page === "settings" ? (
-          <SettingsPage stats={stats} />
         ) : (
           <Routes>
             <Route

--- a/frontend/src/components/ProposalCard.test.tsx
+++ b/frontend/src/components/ProposalCard.test.tsx
@@ -28,6 +28,7 @@ const baseProposal = (overrides: Partial<Proposal> = {}): Proposal => ({
   status: "pending",
   deadline: "Jun 24, 2026",
   createdAt: "proposal #42",
+  proposer: "GPROPO...SER1",
   userHasApproved: false,
   ...overrides,
 });

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -74,7 +74,7 @@ export function mapProposal(raw: any, threshold: number): Proposal {
     status: mapStatus(raw.status),
     deadline: formatDeadline(BigInt(raw.deadline)),
     createdAt: `proposal #${Number(raw.id)}`,
-    proposer: String(raw.proposer),
+    proposer: shortenAddr(String(raw.proposer)),
     userHasApproved: false,
   };
 }

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -28,6 +28,7 @@ export function HistoryPage({
 }) {
   const [activeTab, setActiveTab] = useState<Filter>("all");
   const [searchTerm, setSearchTerm] = useState("");
+  const [proposerFilter, setProposerFilter] = useState("");
   const [displayedProposals, setDisplayedProposals] = useState<Proposal[]>(proposals);
   const [offset, setOffset] = useState<number>(proposals.length);
   const [totalCount, setTotalCount] = useState<number>(0);
@@ -86,6 +87,11 @@ export function HistoryPage({
     .filter((p) => activeTab === "all" || p.status === activeTab)
     .filter((p) =>
       p.description.toLowerCase().includes(searchTerm.toLowerCase())
+    )
+    .filter(
+      (p) =>
+        proposerFilter === "" ||
+        p.proposer.toLowerCase().includes(proposerFilter.toLowerCase())
     );
 
   return (
@@ -108,6 +114,17 @@ export function HistoryPage({
             </button>
           ))}
         </div>
+      </div>
+
+      <div className="mb-4">
+        <input
+          type="text"
+          value={proposerFilter}
+          onChange={(e) => setProposerFilter(e.target.value)}
+          placeholder="Filter by proposer…"
+          aria-label="Filter by proposer"
+          className="w-full bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-2 text-white text-sm placeholder-zinc-600 focus:outline-none focus:border-zinc-700 transition-colors"
+        />
       </div>
 
       <div className="mb-4 relative">
@@ -139,7 +156,7 @@ export function HistoryPage({
       <div className="space-y-3">
         {filteredProposals.length === 0 ? (
           <p className="text-zinc-600 text-sm py-8 text-center">
-            {searchTerm
+            {searchTerm || proposerFilter
               ? "No proposals match your search"
               : `No ${activeTab === "all" ? "" : `${activeTab} `}proposals found`}
           </p>


### PR DESCRIPTION
## Summary

- Populate `proposer` in `mapProposal` using `shortenAddr`, matching the pattern used for the `to` field
- Add a case-insensitive "Filter by proposer…" input on the history page so users can narrow proposals by who created them
- Fix a broken `App.tsx` merge conflict that left duplicate imports, invalid nav JSX, and mixed state-based routing with React Router

Closes #74

## Test plan

- [ ] Open the History page and confirm the "Filter by proposer…" input is visible above the proposal list
- [ ] Type a partial proposer address and verify only matching proposals are shown
- [ ] Clear the filter and confirm all history proposals return
- [ ] Confirm navigation works across dashboard, history, owners, and settings
- [ ] Run `cd frontend && npm run build` locally