### PR TITLE
docs: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report a problem with Accord Protocol
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behaviour
+
+What did you expect to happen?
+
+## Actual Behaviour
+
+What actually happened instead?
+
+## Environment
+
+- **Browser:** (e.g. Chrome 125, Firefox 126)
+- **Wallet extension & version:** (e.g. Freighter 5.2.0)
+- **Network:** (e.g. Testnet, Mainnet, Futurenet)
+
+## Additional Context
+
+Add any other context, logs, or screenshots about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea or enhancement for Accord Protocol
+title: "[Feature]: "
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+A brief summary of the feature you'd like to see.
+
+## Problem
+
+What problem does this solve? Why is this feature needed?
+
+## Proposed Solution
+
+Describe the solution you'd like. Be as specific as possible.
+
+## Alternatives Considered
+
+Have you considered any alternative solutions or workarounds? Why were they not sufficient?
+
+## Additional Context
+
+Add any other context, mockups, or references here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- Briefly describe what this PR changes and why. -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor
+
+## Related Issue
+
+Closes #
+
+## Testing Checklist
+
+- [ ] Existing tests pass locally
+- [ ] New tests added to cover this change (where applicable)
+- [ ] Manually verified the change works as expected
+- [ ] Lint / type checks pass


### PR DESCRIPTION
## Summary

Adds GitHub issue and pull request templates to standardize how
contributors submit bug reports, feature requests, and PRs.

This is a documentation-only change — no code is affected.

## Type of Change

- [x] Documentation

## Related Issue

Closes #170

## What's included

- `.github/ISSUE_TEMPLATE/bug_report.md` — fields for description, steps
  to reproduce, expected behaviour, actual behaviour, and environment
  (browser, wallet extension version, network).
- `.github/ISSUE_TEMPLATE/feature_request.md` — fields for summary,
  problem, proposed solution, and alternatives considered.
- `.github/PULL_REQUEST_TEMPLATE.md` — summary section, change-type
  checklist, testing checklist, and a related-issue prompt.

## Testing Checklist

- [x] All three files are valid Markdown with no broken formatting
- [x] Confirmed correct paths so GitHub auto-detects the templates
- [N/A] No code changes — no tests applicable