### PR TITLE
Fix/issues#77#182#148#144

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -40,6 +40,14 @@ jobs:
         run: |
           stellar contract build --release
 
+      - name: Upload compiled WASM artifact
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: accord-contract-wasm
+          path: target/wasm32-unknown-unknown/release/*.wasm
+          retention-days: 90
+
       - name: Report WASM file sizes
         run: |
           python3 -c '

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,7 +198,18 @@ rent_fee_stroops = ceil(entry_size_bytes / 1024) × fee_rate_1kb × delta_ledger
 
 > These figures use a fee rate of 1 stroop/KB/ledger. Verify the current network value before capacity-planning large deployments; the rate is adjustable via Stellar governance.
 
-### Bump-on-Access Strategy
+### Bump-on-Access Strategy and Configuration
+
+The contract defines the following TTL values for its storage entries:
+- **`INSTANCE_BUMP`**: 518,400 ledgers (≈ 30 days)
+- **`INSTANCE_THRESHOLD`**: 17,280 ledgers (≈ 1 day)
+- **`PERSISTENT_BUMP`**: 518,400 ledgers (≈ 30 days)
+- **`PERSISTENT_THRESHOLD`**: 17,280 ledgers (≈ 1 day)
+
+**Instance storage** bumps on mutating calls, extending the lifetime of the core contract state (`INIT`, `THRESH`, `NEXT`, `ACTCNT`, `TLOCK`). 
+**Persistent storage** bumps per-entry on read or write, meaning that each proposal and approval entry maintains its own independent TTL.
+
+> **Guidance Note**: The bump target must account for the 90-day maximum proposal duration. While the default bump is only 30 days (`518,400` ledgers), this 30-day bump functions correctly only because entries are re-bumped upon access. A proposal with a 90-day deadline will not expire prematurely as long as it is interacted with (read or written) at least once every 30 days.
 
 Every read or write of a storage entry calls `extend_ttl` with a **threshold** and a **bump**:
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,6 +21,22 @@ Read the [README](../README.md) and [Architecture](./ARCHITECTURE.md) for produc
 
 ---
 
+## Your First Contribution
+
+This checklist is designed for first-time contributors to help you get started quickly and smoothly. It links to the more detailed sections below for further guidance.
+
+- [ ] Read the [Architecture](./ARCHITECTURE.md) and [Setup](./SETUP.md) documentation.
+- [ ] Clone the repository or fork it to your local machine.
+- [ ] Run the installation commands as detailed in the [Development Setup](#development-setup) / [SETUP.md](./SETUP.md).
+- [ ] Verify that your local builds succeed.
+- [ ] Find an issue to work on (look for `good first issue`) via [Finding Work](#finding-work).
+- [ ] Create a new branch following the conventions in [Branching and Commits](#branching-and-commits).
+- [ ] Make your change and ensure it is as small as possible to satisfy the issue.
+- [ ] Run local checks and tests (see [Testing](#testing)).
+- [ ] Open a Pull Request and respond to feedback.
+
+---
+
 ## Ways to Contribute
 
 | Area | Examples |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ export default function App() {
   const [showCreate, setShowCreate] = useState(false);
   const [txError, setTxError] = useState<string | null>(null);
   const [txPending, setTxPending] = useState(false);
+  const [isStale, setIsStale] = useState(false);
 
   const wallet = useWallet();
   const navigate = useNavigate();
@@ -50,6 +51,7 @@ export default function App() {
     error,
     refresh,
     optimisticUpdate,
+    lastSuccessAt,
   } = useContract(wallet.address);
 
   useEventPolling(refresh, 5000);
@@ -64,6 +66,17 @@ export default function App() {
       setTxError("Wallet disconnected. Please reconnect and try again.");
     }
   }, [wallet.address, txPending]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (lastSuccessAt) {
+        setIsStale(Date.now() - lastSuccessAt > 60000);
+      } else {
+        setIsStale(false);
+      }
+    }, 10000);
+    return () => clearInterval(interval);
+  }, [lastSuccessAt]);
 
   const activeProposals = proposals.filter((proposal) =>
     ["pending", "ready"].includes(proposal.status),
@@ -225,6 +238,12 @@ export default function App() {
       </header>
 
       <main className="mx-auto max-w-4xl px-6 py-8">
+        {isStale && !loading && (
+          <div className="mb-6 rounded-xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-400 font-medium">
+            Data may be out of date — last updated over 60 seconds ago.
+          </div>
+        )}
+
         {txError && (
           <div className="mb-6 flex items-center justify-between rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-400">
             <span>{txError}</span>

--- a/frontend/src/hooks/useContract.ts
+++ b/frontend/src/hooks/useContract.ts
@@ -18,6 +18,7 @@ type ContractState = {
   error: string | null;
   refresh: () => void;
   optimisticUpdate: (id: number, patch: Partial<Proposal>) => void;
+  lastSuccessAt: number | null;
 };
 
 export function useContract(walletAddress: string | null): ContractState {
@@ -28,6 +29,7 @@ export function useContract(walletAddress: string | null): ContractState {
   const [stats, setStats] = useState<DashboardStat[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [lastSuccessAt, setLastSuccessAt] = useState<number | null>(null);
 
   const refresh = useCallback(() => setTick((t) => t + 1), []);
 
@@ -100,6 +102,10 @@ export function useContract(walletAddress: string | null): ContractState {
           { label: "Total", value: String(total), sub: "proposals created" },
           { label: "Executed", value: String(executed), sub: "all time" },
         ]);
+        
+        if (!cancelled) {
+          setLastSuccessAt(Date.now());
+        }
       } catch (err) {
         if (!cancelled) {
           setError(
@@ -125,5 +131,6 @@ export function useContract(walletAddress: string | null): ContractState {
     error,
     refresh,
     optimisticUpdate,
+    lastSuccessAt,
   };
 }


### PR DESCRIPTION
Closes #77
Closes #182
Closes #148
Closes #144

Frontend — Stale Data Warning Banner

Modified 
useContract.ts
 to introduce a lastSuccessAt state value, updated with Date.now() upon a successful fetch of the contract's data.
Updated 
App.tsx
 with a useEffect implementing a 10-second polling interval to set the boolean state isStale if lastSuccessAt hasn't been updated for 60 seconds.
Rendered a non-dismissible amber warning banner when the app is stale.
Committed: feat(frontend): add stale data warning banner on 60s timeout

Smart Contract — Build & CI Artifacts

Modified the 
contract.yml
 workflow file.
Appended a conditional actions/upload-artifact step after the stellar contract build --release step. It only runs if github.ref == 'refs/heads/main' and github.event_name == 'push', targeting the *.wasm output file with a 90-day retention.
Committed: ci(contract): upload compiled wasm artifact on main branch push

Docs — Setup & Onboarding Checklist

Expanded 
CONTRIBUTING.md
 just below the Table of Contents.
Added a "Your First Contribution" section containing a short preamble for new contributors, and a comprehensive 9-step Markdown checklist.
Committed: docs: add step-by-step first contribution checklist to CONTRIBUTING.md
Docs — Storage & TTL API Reference

Updated the Storage Layout section of 
ARCHITECTURE.md
.
Documented the constants INSTANCE_BUMP, INSTANCE_THRESHOLD, PERSISTENT_BUMP, and PERSISTENT_THRESHOLD translating them to their respective ~30-day and ~1-day horizons.
Clarified that Instance Storage is bumped on mutating calls, whereas Persistent Storage is bumped upon per-entry reads and writes.
Added a guidance note explaining how the 30-day target effectively accommodates the 90-day maximum proposal lifespan by repeatedly bumping back to 30 days upon each access.
Committed: docs: document soroban storage ttl, bump strategies, and lifecycle costs