### PR TITLE
docs: resolve issues #167, #171, #172, #173 — contributing guide, roadmap, code of conduct, and docs page

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -8,7 +8,7 @@
       "name": "thegreatfeez",
       "avatar_url": "https://avatars.githubusercontent.com/u/thegreatfeez?v=4",
       "profile": "https://github.com/thegreatfeez",
-      "contributions": ["code", "doc", "ideas"]
+      "contributions": ["code", "doc", "ideas", "test", "infra"]
     }
   ],
   "contributorsPerLine": 7,

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,131 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer at <theaccordprotocol@gmail.com>. All
+complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,10 +26,11 @@ Please read the [README](./README.md) first for product context, architecture, a
 
 ## Code of conduct and collaboration
 
+This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md). By participating, you agree to uphold its standards.
+
 - **Be respectful and constructive.** Review comments should focus on the change, not the person.
 - **Assume good intent** and prefer clear questions over assumptions.
 - **Keep discussions on-topic** in issues and pull requests (PRs).
-- If the project adopts a formal Code of Conduct later, it will supersede this section; until then, these expectations apply to all spaces where the project is discussed (issues, PRs, chats linked from the repo).
 
 Harassment, discrimination, or abusive behavior are not acceptable. Maintainers may remove disruptive content and, when necessary, block participation to protect contributors.
 
@@ -202,6 +203,10 @@ Understanding where code belongs reduces review churn and merge conflicts.
 
 ## Finding work and program participation
 
+### Project roadmap
+
+Check [`ROADMAP.md`](./ROADMAP.md) for an overview of upcoming milestones, targeted features, and acceptance criteria. The roadmap helps you understand what is planned versus already shipped and where your contribution would have the most impact.
+
 ### GitHub issues
 
 - Use **open issues** as the primary source of scoped work.
@@ -231,6 +236,32 @@ If an issue is labeled for Wave eligibility, treat the label as informational on
 6. **Respond to review feedback** in a timely way; it is normal to go through several review rounds.
 
 If you discover that an issue is **wrongly scoped** or **blocked**, comment on the issue early rather than investing days of work in the wrong direction.
+
+### What happens after you open a PR
+
+Once the pull request is open, maintainers will review it. You can expect a first review within a few days for non-trivial changes. Review comments appear directly on the PR under the "Files changed" tab or in the general conversation thread. A maintainer may also request a review from another contributor with domain expertise (for example, a contract change may be reviewed by someone familiar with Soroban patterns).
+
+### Review and merge criteria
+
+Before a PR is merged, reviewers check the following:
+
+- **Tests pass** — all CI checks (contract tests, frontend build, lint) are green.
+- **Scope matches the issue** — the PR addresses the linked issue without unrelated changes.
+- **Coding standards followed** — the change matches the style and patterns of surrounding code.
+- **Description is complete** — the PR includes what changed, why, how to verify, and any known follow-ups.
+- **Tests added or updated** — behavior changes include test coverage where applicable.
+
+Once all criteria are met, a maintainer will approve the PR and merge it into `main`. PRs that require significant changes may go through several review rounds before approval.
+
+### Handling review feedback
+
+When a reviewer requests changes, push follow-up commits to the same branch. The new commits appear automatically in the open PR. Use the "Resolve conversation" button on each review comment thread once you have addressed the feedback. If you disagree with a suggestion, respond with a counter-argument explaining your reasoning — constructive back-and-forth is expected and welcome. If the discussion reaches an impasse, the maintainer makes the final call.
+
+### After your PR merges
+
+- The feature branch can be deleted (GitHub offers this automatically for branches in the same repo).
+- Your name and avatar appear in the commit history of the repository.
+- The change will be included in the next release — check [`CHANGELOG.md`](./CHANGELOG.md) for the version that ships your contribution.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,34 +234,39 @@ If an issue is labeled for Wave eligibility, treat the label as informational on
 4. **Run local checks** (see [Testing and quality gates](#testing-and-quality-gates)).
 5. **Open a pull request** into the default branch with a clear title and description.
 6. **Respond to review feedback** in a timely way; it is normal to go through several review rounds.
+7. **After your PR merges**, clean up and move on (see below).
 
 If you discover that an issue is **wrongly scoped** or **blocked**, comment on the issue early rather than investing days of work in the wrong direction.
 
 ### What happens after you open a PR
 
-Once the pull request is open, maintainers will review it. You can expect a first review within a few days for non-trivial changes. Review comments appear directly on the PR under the "Files changed" tab or in the general conversation thread. A maintainer may also request a review from another contributor with domain expertise (for example, a contract change may be reviewed by someone familiar with Soroban patterns).
+Once your pull request is open, a maintainer will review it. Expect a first review within a few days; complex changes may take longer. Review comments appear directly on the PR in GitHub — on specific lines of code, on the overall diff, or as general discussion. Subscribe to email notifications for the PR so you do not miss feedback.
 
 ### Review and merge criteria
 
-Before a PR is merged, reviewers check the following:
+Reviewers check that the PR meets these conditions before approving:
 
-- **Tests pass** — all CI checks (contract tests, frontend build, lint) are green.
-- **Scope matches the issue** — the PR addresses the linked issue without unrelated changes.
-- **Coding standards followed** — the change matches the style and patterns of surrounding code.
-- **Description is complete** — the PR includes what changed, why, how to verify, and any known follow-ups.
-- **Tests added or updated** — behavior changes include test coverage where applicable.
+- **Tests pass.** All CI checks (contract tests, frontend lint, and frontend build) are green.
+- **Scope matches the issue.** The change addresses the issue it claims to fix without unrelated drive-by refactors.
+- **Coding standards followed.** The code matches the style and patterns described in [Coding standards](#coding-standards).
+- **Description is complete.** The PR description explains what changed, why, how to verify it, and links the relevant issue.
 
-Once all criteria are met, a maintainer will approve the PR and merge it into `main`. PRs that require significant changes may go through several review rounds before approval.
+Once all criteria are met, a maintainer approves the PR and merges it into `main`.
 
 ### Handling review feedback
 
-When a reviewer requests changes, push follow-up commits to the same branch. The new commits appear automatically in the open PR. Use the "Resolve conversation" button on each review comment thread once you have addressed the feedback. If you disagree with a suggestion, respond with a counter-argument explaining your reasoning — constructive back-and-forth is expected and welcome. If the discussion reaches an impasse, the maintainer makes the final call.
+When a reviewer requests changes:
+
+1. **Push follow-up commits** to the same branch. Do not open a new PR — the existing PR updates automatically.
+2. **Reply to each review comment** explaining what you changed or why you kept the current approach.
+3. **Mark comments as resolved** in the GitHub UI once the feedback has been addressed.
+4. If you disagree with feedback, **push back with a counter-argument** in the review thread. Explain your reasoning, link supporting references if applicable, and come to a consensus before proceeding. Reviewers are collaborators, not gatekeepers — discussion is expected.
 
 ### After your PR merges
 
-- The feature branch can be deleted (GitHub offers this automatically for branches in the same repo).
-- Your name and avatar appear in the commit history of the repository.
-- The change will be included in the next release — check [`CHANGELOG.md`](./CHANGELOG.md) for the version that ships your contribution.
+- **Delete your feature branch** to keep the repository tidy. GitHub offers a button for this after merge.
+- **Your name appears in the commit history** as a contributor to the project.
+- **Check the changelog** (`CHANGELOG.md`) to see your change listed in the next release, or follow the [issue tracker](https://github.com/thegreatfeez/accord-protocol/issues) for release announcements.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,79 @@
+# Roadmap
+
+Accord aims to become the default on-chain multisig treasury layer for teams building on Stellar. The roadmap is shaped by three priorities, applied in order: security first (audited contracts, hardened authorization), then usability (clean frontend, clear docs), and finally ecosystem reach (integrations, mainnet readiness). Each milestone below targets a concrete set of features and ships only when every acceptance criterion is met.
+
+## Current status
+
+The project is actively working toward **v0.2.0** (below). Open issues for this milestone can be found in the [issue tracker](https://github.com/thegreatfeez/accord-protocol/issues).
+
+---
+
+## v0.2.0 — Governance and usability
+
+**Theme:** Expand the proposal lifecycle so multisigs can govern themselves (add/remove owners, change thresholds) and make the frontend more usable for day-to-day treasury operations.
+
+**Targeted features:**
+
+- Owner management proposals (add and remove owners through the multisig flow)
+- Threshold change proposals (adjust M-of-N requirements without redeploying)
+- Revoke button in the UI so owners can withdraw approvals before execution
+- Real-time event feed for proposal activity (on-chain events wired to UI notifications)
+- Proposal categories and tagging (Transfer, Payroll, Grant, Ops, Other)
+
+**Acceptance criteria:**
+
+- [ ] `create_add_owner_proposal` and `create_remove_owner_proposal` functions are implemented and tested
+- [ ] `create_change_threshold_proposal` is implemented and tested
+- [ ] Revoking an approval transitions a Ready proposal back to Pending when approvals fall below threshold
+- [ ] The frontend displays a Revoke button on Pending and Ready proposals for the connected owner
+- [ ] Proposal categories are displayed in the dashboard and filterable
+- [ ] All contract tests pass (`stellar contract test`)
+- [ ] Frontend lint and build pass (`npm run lint && npm run build`)
+
+---
+
+## v0.3.0 — Production readiness
+
+**Theme:** Harden the contract and frontend for mainnet-class usage with time-locked execution, comprehensive access controls, and a security audit.
+
+**Targeted features:**
+
+- Time-locked execution (enforce a configurable delay after threshold is met before execution is allowed)
+- Per-owner spending limits (optional caps on proposal amounts per signer)
+- Multi-token treasury dashboard (aggregate balances for all held tokens)
+- Mobile-responsive UI
+- Security audit by an independent reviewer
+- SEP-55 contract build verification in CI (GitHub Actions attestation pipeline)
+
+**Acceptance criteria:**
+
+- [ ] Time-lock delay is configurable at initialization and enforced during execute
+- [ ] Per-owner spending limits can be set and are checked on proposal creation
+- [ ] The dashboard displays token balances for all tokens held by the contract
+- [ ] The frontend is fully responsive on mobile viewports
+- [ ] A security audit report is published in `docs/`
+- [ ] CI pipeline builds, attests, and verifies the contract WASM per SEP-55
+- [ ] All existing tests continue to pass
+
+---
+
+## v1.0.0 — Mainnet launch
+
+**Theme:** Ship a production-grade, audited multisig treasury system ready for real funds on Stellar mainnet.
+
+**Targeted features:**
+
+- Mainnet deployment guide and tooling
+- Upgradeable contract with multi-sig co-signed upgrades
+- Full documentation suite (setup, API reference, architecture, security, deployment)
+- Monitoring and alerting for on-chain proposal activity
+- Community governance process for protocol changes
+
+**Acceptance criteria:**
+
+- [ ] Contract is deployed to Stellar mainnet and verified on the block explorer
+- [ ] Deployment guide is complete and tested by at least one independent contributor
+- [ ] The upgrade path (multi-sig co-signed WASM replacement) works on mainnet
+- [ ] Documentation covers all contract functions, frontend workflows, and deployment steps
+- [ ] No known critical or high-severity vulnerabilities remain open
+- [ ] The project has at least three external contributors who have merged PRs

--- a/frontend/src/pages/DocsPage.tsx
+++ b/frontend/src/pages/DocsPage.tsx
@@ -5,6 +5,7 @@ const SECTIONS = [
   { id: "what-is-accord", label: "What is Accord?" },
   { id: "getting-started", label: "Getting Started" },
   { id: "proposal-lifecycle", label: "Proposal Lifecycle" },
+  { id: "approving-and-executing", label: "Approving & Executing" },
   { id: "faq", label: "FAQ" },
 ] as const;
 
@@ -271,6 +272,74 @@ export function DocsPage() {
               </span>
               .
             </p>
+          </section>
+
+          <section
+            id="approving-and-executing"
+            className="scroll-mt-24 rounded-3xl border border-zinc-900 bg-zinc-950 p-8"
+          >
+            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-emerald-400">
+              Governance
+            </p>
+            <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+              Approving and Executing
+            </h2>
+            <p className="mt-4 text-sm leading-7 text-zinc-400 sm:text-base">
+              Once a proposal is created, the multisig approval process determines
+              whether it is ready for execution. This section explains who can
+              approve, how the threshold works, and what happens when a proposal
+              is executed.
+            </p>
+
+            <div className="mt-8 space-y-8">
+              <div>
+                <h3 className="text-xl font-semibold text-white">
+                  Who Can Approve
+                </h3>
+                <p className="mt-3 text-sm leading-7 text-zinc-400 sm:text-base">
+                  Only addresses in the multisig owners list can approve, revoke,
+                  or execute proposals. If you connect a wallet that is not an
+                  owner, you will see the dashboard in read-only mode: you can
+                  browse proposals and check their status, but you cannot sign any
+                  governance actions. This is enforced on-chain — the contract
+                  verifies owner status before processing any approve, revoke, or
+                  execute call.
+                </p>
+              </div>
+
+              <div>
+                <h3 className="text-xl font-semibold text-white">
+                  How the Threshold Works
+                </h3>
+                <p className="mt-3 text-sm leading-7 text-zinc-400 sm:text-base">
+                  Every proposal starts in <strong className="text-white">Pending</strong> status. Each owner may add one approval per proposal. The moment the approval count reaches the configured threshold (for example, 2 out of 3 owners), the proposal automatically transitions to <strong className="text-white">Ready</strong>. No manual action is needed — the contract handles the status change on-chain when the threshold is crossed.
+                </p>
+                <p className="mt-3 text-sm leading-7 text-zinc-400 sm:text-base">
+                  Owners can also revoke an approval. If revoking drops the count below the threshold, the proposal transitions back to Pending. This means approvals are not final until execution — owners can change their mind as long as the proposal has not been executed yet.
+                </p>
+              </div>
+
+              <div>
+                <h3 className="text-xl font-semibold text-white">
+                  Executing a Proposal
+                </h3>
+                <p className="mt-3 text-sm leading-7 text-zinc-400 sm:text-base">
+                  Once a proposal reaches Ready status, any owner can press Execute. The contract then transfers tokens directly from the multisig account to the recipient specified in the proposal. For governance proposals (such as adding or removing an owner, or changing the threshold), the corresponding state change is applied on-chain instead of a token transfer.
+                </p>
+                <p className="mt-3 text-sm leading-7 text-zinc-400 sm:text-base">
+                  Execution is blocked if the proposal deadline has already passed — in that case the proposal is considered Expired and can no longer be executed. The contract also enforces any configured time-lock delay, meaning execution is not possible until a waiting period after the threshold is first met has elapsed.
+                </p>
+              </div>
+
+              <div>
+                <h3 className="text-xl font-semibold text-white">
+                  After Execution
+                </h3>
+                <p className="mt-3 text-sm leading-7 text-zinc-400 sm:text-base">
+                  When a proposal is successfully executed, its status moves to <strong className="text-white">Executed</strong>. The proposal is removed from the active proposals count and will no longer appear in the main dashboard view. You can find executed proposals in the history section of the app, where the full lifecycle — including who proposed, who approved, and when it was executed — remains visible for audit purposes.
+                </p>
+              </div>
+            </div>
           </section>
 
           <section

--- a/frontend/src/pages/DocsPage.tsx
+++ b/frontend/src/pages/DocsPage.tsx
@@ -282,13 +282,14 @@ export function DocsPage() {
               Governance
             </p>
             <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">
-              Approving and Executing
+              Approving &amp; Executing
             </h2>
             <p className="mt-4 text-sm leading-7 text-zinc-400 sm:text-base">
-              Once a proposal is created, the multisig approval process determines
-              whether it is ready for execution. This section explains who can
-              approve, how the threshold works, and what happens when a proposal
-              is executed.
+              Once a proposal exists on-chain, the multisig owners review it and
+              decide whether to approve. When enough owners approve, the proposal
+              becomes executable. This section explains who can take these actions,
+              how the threshold mechanism works, and what happens during and after
+              execution.
             </p>
 
             <div className="mt-8 space-y-8">
@@ -297,13 +298,12 @@ export function DocsPage() {
                   Who Can Approve
                 </h3>
                 <p className="mt-3 text-sm leading-7 text-zinc-400 sm:text-base">
-                  Only addresses in the multisig owners list can approve, revoke,
-                  or execute proposals. If you connect a wallet that is not an
-                  owner, you will see the dashboard in read-only mode: you can
-                  browse proposals and check their status, but you cannot sign any
-                  governance actions. This is enforced on-chain — the contract
-                  verifies owner status before processing any approve, revoke, or
-                  execute call.
+                  Only addresses that are part of the multisig owners list can
+                  approve, revoke, or execute proposals. The contract checks the
+                  caller's authorization against the stored owners on every
+                  action. If your address is not in the owners list, the dashboard
+                  displays a read-only view of the proposals — you can observe
+                  the multisig activity but cannot sign or submit transactions.
                 </p>
               </div>
 
@@ -312,10 +312,19 @@ export function DocsPage() {
                   How the Threshold Works
                 </h3>
                 <p className="mt-3 text-sm leading-7 text-zinc-400 sm:text-base">
-                  Every proposal starts in <strong className="text-white">Pending</strong> status. Each owner may add one approval per proposal. The moment the approval count reaches the configured threshold (for example, 2 out of 3 owners), the proposal automatically transitions to <strong className="text-white">Ready</strong>. No manual action is needed — the contract handles the status change on-chain when the threshold is crossed.
+                  Each owner may add exactly one approval per proposal. The
+                  approval count is stored on-chain and compared against the
+                  configured threshold — for example, a 2-of-3 multisig requires
+                  two approvals before a proposal is ready. The moment the
+                  approval count reaches the threshold, the proposal status
+                  automatically transitions from Pending to Ready.
                 </p>
                 <p className="mt-3 text-sm leading-7 text-zinc-400 sm:text-base">
-                  Owners can also revoke an approval. If revoking drops the count below the threshold, the proposal transitions back to Pending. This means approvals are not final until execution — owners can change their mind as long as the proposal has not been executed yet.
+                  If an owner revokes their approval after the threshold has been
+                  reached and the count drops back below the threshold, the
+                  proposal status returns to Pending. This means the multisig can
+                  reconsider a proposal before execution as long as no owner has
+                  already executed it.
                 </p>
               </div>
 
@@ -324,10 +333,18 @@ export function DocsPage() {
                   Executing a Proposal
                 </h3>
                 <p className="mt-3 text-sm leading-7 text-zinc-400 sm:text-base">
-                  Once a proposal reaches Ready status, any owner can press Execute. The contract then transfers tokens directly from the multisig account to the recipient specified in the proposal. For governance proposals (such as adding or removing an owner, or changing the threshold), the corresponding state change is applied on-chain instead of a token transfer.
+                  Any multisig owner can press Execute once a proposal has reached
+                  the Ready state. When executed, the contract transfers tokens
+                  directly from the multisig account to the recipient address
+                  specified in the proposal. For governance proposals — such as
+                  adding or removing an owner, or changing the threshold — the
+                  corresponding state change is applied instead of a token
+                  transfer.
                 </p>
                 <p className="mt-3 text-sm leading-7 text-zinc-400 sm:text-base">
-                  Execution is blocked if the proposal deadline has already passed — in that case the proposal is considered Expired and can no longer be executed. The contract also enforces any configured time-lock delay, meaning execution is not possible until a waiting period after the threshold is first met has elapsed.
+                  Execution is blocked if the proposal deadline has already passed.
+                  Expired proposals cannot be executed; they must be replaced with
+                  a new proposal if the action is still needed.
                 </p>
               </div>
 
@@ -336,7 +353,11 @@ export function DocsPage() {
                   After Execution
                 </h3>
                 <p className="mt-3 text-sm leading-7 text-zinc-400 sm:text-base">
-                  When a proposal is successfully executed, its status moves to <strong className="text-white">Executed</strong>. The proposal is removed from the active proposals count and will no longer appear in the main dashboard view. You can find executed proposals in the history section of the app, where the full lifecycle — including who proposed, who approved, and when it was executed — remains visible for audit purposes.
+                  Once execution succeeds, the proposal moves to Executed status
+                  and is removed from the active list on the dashboard. You can
+                  find executed proposals in the history view, where the full
+                  lifecycle — who proposed it, who approved, and when it was
+                  executed — remains visible for audit purposes.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
This PR resolves four documentation issues to improve contributor onboarding and project transparency:
- #171 — Adds CODE_OF_CONDUCT.md (Contributor Covenant v2.1) and updates .all-contributorsrc with test and infra contribution types
- #172 — Creates ROADMAP.md with versioned milestones (v0.2, v0.3, v1.0), acceptance criteria, and current status
- #173 — Expands CONTRIBUTING.md with a complete PR workflow covering review phase, merge criteria, handling feedback, and post-merge steps
- #167 — Adds "Approving & Executing" section to DocsPage.tsx explaining who can approve, threshold mechanics, execution preconditions, and post-execution status
## Changes
### New files
- CODE_OF_CONDUCT.md — Contributor Covenant v2.1 with enforcement contact
- ROADMAP.md — Forward-looking roadmap with three milestones and acceptance criteria
Modified files
- CONTRIBUTING.md — Added Code of Conduct link, roadmap link, and full PR workflow walkthrough
- .all-contributorsrc — Added test and infra to contribution types
- frontend/src/pages/DocsPage.tsx — Added "Approving & Executing" section with sidebar link
Acceptance Criteria
- [x] CONTRIBUTING.md describes what happens after a PR is opened, including the review phase
- [x] "Review and merge criteria" section exists and lists observable conditions a PR must meet
- [x] File explains how to respond to and resolve review comments
- [x] File explains what to do after the PR is merged
- [x] ROADMAP.md exists with at least three milestones, each with version label, theme, and acceptance criteria
- [x] "Current status" section identifies which milestone is actively being worked on
- [x] CONTRIBUTING.md contains a link to ROADMAP.md
- [x] CODE_OF_CONDUCT.md exists with full Contributor Covenant v2.1 text
- [x] CONTRIBUTING.md contains a link to CODE_OF_CONDUCT.md
- [x] .all-contributorsrc lists test and infra in contributions array
- [x] DocsPage shows "Approving & Executing" section with sidebar link
- [x] Threshold mechanic (Pending → Ready) is described
- [x] Execute preconditions (Ready status, deadline not passed) are described
- [x] Section contains no code blocks — prose only

closes #171 
closes #172 
closes #173 
closes #167 