### PR TITLE
feat: show individual approver addresses in ApprovalBar tooltip

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -319,32 +319,6 @@ export default function App() {
           <div className="py-16 text-center text-sm text-zinc-500">
             Loading contract data…
           </div>
-        ) : page === "dashboard" ? (
-          <DashboardPage
-            activeProposals={activeProposals}
-            owners={owners}
-            dashboardStats={stats}
-            walletAddress={wallet.address}
-            onApprove={handleApprove}
-            onExecute={handleExecute}
-            onRevoke={handleRevoke}
-            onCreateProposal={() => setShowCreate(true)}
-            error={null}
-            loading={loading}
-          />
-        ) : page === "history" ? (
-          <HistoryPage proposals={proposals} onApprove={handleApprove} />
-        ) : page === "owners" ? (
-          <OwnersPage
-            owners={owners}
-            threshold={parseInt(
-              stats.find((s) => s.label === "Threshold")?.value.split(" ")[0] ||
-                "0",
-            )}
-            totalOwners={owners.length}
-          />
-        ) : page === "settings" ? (
-          <SettingsPage stats={stats} />
         ) : (
           <Routes>
             <Route
@@ -389,7 +363,7 @@ export default function App() {
           </Routes>
         )}
       </main>
-
+      
       {showCreate && (
         <CreateProposalModal
           walletAddress={wallet.address}

--- a/frontend/src/components/ApprovalBar.tsx
+++ b/frontend/src/components/ApprovalBar.tsx
@@ -1,13 +1,33 @@
-export function ApprovalBar({ approvals, threshold }: { approvals: number; threshold: number }) {
+type ApprovalBarProps = {
+  approvals: number;
+  threshold: number;
+  approverAddresses?: string[];
+};
+
+export function ApprovalBar({ approvals, threshold, approverAddresses = [] }: ApprovalBarProps) {
   return (
     <div className="flex items-center gap-2" aria-label={`${approvals} of ${threshold} approvals`}>
       <div className="flex gap-1">
-        {Array.from({ length: threshold }).map((_, i) => (
-          <div
-            key={i}
-            className={`w-2 h-2 rounded-full ${i < approvals ? "bg-emerald-400" : "bg-zinc-700"}`}
-          />
-        ))}
+        {Array.from({ length: threshold }).map((_, i) => {
+          const isApproved = i < approvals;
+          
+          // Truncate the address if this dot represents an approval
+          let tooltipTitle = undefined;
+          if (isApproved && approverAddresses[i]) {
+            const addr = approverAddresses[i];
+            tooltipTitle = `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+          }
+
+          return (
+            <div
+              key={i}
+              title={tooltipTitle} // Native HTML tooltip
+              className={`w-2 h-2 rounded-full ${
+                isApproved ? "bg-emerald-400" : "bg-zinc-700"
+              }`}
+            />
+          );
+        })}
       </div>
       <span className="text-xs text-zinc-500 font-mono">
         {approvals}/{threshold}

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -132,7 +132,11 @@ export function ProposalCard({
       </div>
 
       <div className="flex items-center justify-between mt-4">
-        <ApprovalBar approvals={proposal.approvals} threshold={proposal.threshold} />
+        <ApprovalBar 
+          approvals={proposal.approvals} 
+          threshold={proposal.threshold} 
+          approverAddresses={proposal.approverAddresses}
+        />
 
         <div className="flex items-center gap-2">
           <span className="text-xs text-zinc-600">{proposal.createdAt}</span>

--- a/frontend/src/hooks/useContract.ts
+++ b/frontend/src/hooks/useContract.ts
@@ -6,6 +6,7 @@ import {
   getTotalProposals,
   mapProposal,
   hasApproved,
+  getApprovers,
 } from "../lib/contract";
 import type { DashboardStat, Owner, Proposal } from "../types/accord";
 
@@ -63,15 +64,18 @@ export function useContract(walletAddress: string | null): ContractState {
 
         const proposalsWithApproval = await Promise.all(
           mapped.map(async (p) => {
+
+            const approverAddresses = await getApprovers(p.id);
+
             if (!walletAddress) {
-              return { ...p, userHasApproved: false };
+              return { ...p, userHasApproved: false, approverAddresses };
             }
             try {
               const approved = await hasApproved(walletAddress, p.id);
-              return { ...p, userHasApproved: approved };
+              return { ...p, userHasApproved: approved, approverAddresses };
             } catch (err) {
               console.error(`Failed to fetch approval for ${p.id}`, err);
-              return { ...p, userHasApproved: false };
+              return { ...p, userHasApproved: false, approverAddresses };
             }
           })
         );

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -130,6 +130,7 @@ export function mapProposal(raw: any, threshold: number): Proposal {
     createdAt: `proposal #${Number(raw.id)}`,
     proposer: shortenAddr(String(raw.proposer)),
     userHasApproved: false,
+    approverAddresses: [],
   };
 }
 
@@ -207,5 +208,25 @@ export async function getContractEvents(fromLedger: number): Promise<number> {
   } catch (err) {
     console.error("Failed to get contract events:", err);
     return fromLedger;
+  }
+}
+
+export async function getApprovers(proposalId: number): Promise<string[]> {
+  try {
+    const owners = await getOwners();
+    
+    // Check all owners in parallel
+    const checks = await Promise.all(
+      owners.map(async (owner) => {
+        const approved = await hasApproved(owner, proposalId);
+        return { owner, approved };
+      })
+    );
+
+    // Keep only the ones who approved
+    return checks.filter((c) => c.approved).map((c) => c.owner);
+  } catch (error) {
+    console.error(`Failed to get approvers for proposal ${proposalId}:`, error);
+    return [];
   }
 }

--- a/frontend/src/pages/ProposalDetailPage.tsx
+++ b/frontend/src/pages/ProposalDetailPage.tsx
@@ -1,109 +1,4 @@
 import { Link, useParams } from "react-router-dom";
-import { useProposal } from "../hooks/useProposal";
-
-export function ProposalDetailPage() {
-  const { id: idParam } = useParams();
-  const proposalId = idParam ? Number(idParam) : NaN;
-  const invalidId = !idParam || Number.isNaN(proposalId);
-  const { proposal, loading, error } = useProposal(invalidId ? -1 : proposalId);
-
-  return (
-    <div className="space-y-8">
-      <div className="mb-6 flex flex-wrap items-center gap-2 text-sm text-zinc-400">
-        <Link
-          to="/app"
-          className="font-medium text-zinc-400 hover:text-zinc-200 transition-colors"
-        >
-          Dashboard
-        </Link>
-        <span className="text-zinc-600">›</span>
-        <span className="font-semibold text-white whitespace-nowrap">
-          Proposal #{idParam ?? ""}
-        </span>
-      </div>
-
-      {invalidId ? (
-        <div className="rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-5 text-sm text-red-200">
-          Invalid proposal id.
-        </div>
-      ) : loading ? (
-        <div className="py-16 text-center text-zinc-500">
-          Loading proposal details…
-        </div>
-      ) : error ? (
-        <div className="rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-5 text-sm text-red-200">
-          {error}
-        </div>
-      ) : !proposal ? (
-        <div className="rounded-xl border border-zinc-800 bg-zinc-900 px-4 py-5 text-sm text-zinc-300">
-          Proposal not found.
-        </div>
-      ) : (
-        <section className="space-y-6">
-          <div className="rounded-3xl border border-zinc-800 bg-zinc-900 p-6">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <p className="text-xs text-zinc-500 font-mono mb-1">
-                  Proposal #{proposal.id}
-                </p>
-                <h1 className="text-2xl font-semibold text-white">
-                  Send {proposal.amount} {proposal.token}
-                </h1>
-              </div>
-              <div className="rounded-full bg-zinc-800 px-3 py-1 text-xs uppercase tracking-wide text-zinc-300">
-                {proposal.status}
-              </div>
-            </div>
-
-            <div className="mt-6 grid gap-4 sm:grid-cols-2">
-              <div className="rounded-2xl border border-zinc-800 bg-zinc-950/40 p-4">
-                <p className="text-xs uppercase tracking-wide text-zinc-500">
-                  Recipient
-                </p>
-                <p className="mt-2 text-sm text-zinc-200">{proposal.to}</p>
-              </div>
-              <div className="rounded-2xl border border-zinc-800 bg-zinc-950/40 p-4">
-                <p className="text-xs uppercase tracking-wide text-zinc-500">
-                  Proposed by
-                </p>
-                <p className="mt-2 text-sm text-zinc-200">
-                  {proposal.proposer}
-                </p>
-              </div>
-            </div>
-
-            <div className="mt-6 grid gap-4 sm:grid-cols-2">
-              <div className="rounded-2xl border border-zinc-800 bg-zinc-950/40 p-4">
-                <p className="text-xs uppercase tracking-wide text-zinc-500">
-                  Created
-                </p>
-                <p className="mt-2 text-sm text-zinc-200">
-                  {proposal.createdAt}
-                </p>
-              </div>
-              <div className="rounded-2xl border border-zinc-800 bg-zinc-950/40 p-4">
-                <p className="text-xs uppercase tracking-wide text-zinc-500">
-                  Approvals
-                </p>
-                <p className="mt-2 text-sm text-zinc-200">
-                  {proposal.approvals}/{proposal.threshold}
-                </p>
-              </div>
-            </div>
-
-            {proposal.description && (
-              <div className="mt-6 rounded-2xl border border-zinc-800 bg-zinc-950/40 p-4">
-                <p className="text-xs uppercase tracking-wide text-zinc-500 mb-2">
-                  Description
-                </p>
-                <p className="text-sm leading-6 text-zinc-300">
-                  {proposal.description}
-                </p>
-              </div>
-            )}
-          </div>
-        </section>
-      )}
 import { StatusBadge } from "../components/StatusBadge";
 import { useProposal } from "../hooks/useProposal";
 
@@ -111,7 +6,9 @@ export function ProposalDetailPage() {
   const { id } = useParams();
   const proposalId = Number(id);
   const isValidProposalId = Number.isInteger(proposalId) && proposalId > 0;
-  const { proposal, loading, error } = useProposal(proposalId);
+  
+  // Pass a valid ID or a fallback (-1) so the hook doesn't attempt to fetch NaN
+  const { proposal, loading, error } = useProposal(isValidProposalId ? proposalId : -1);
 
   if (!isValidProposalId) {
     return (
@@ -148,7 +45,7 @@ export function ProposalDetailPage() {
 
         {loading && (
           <div className="rounded-3xl border border-zinc-900 bg-zinc-950 p-8 text-sm text-zinc-400">
-            Loading proposal details…
+            Loading proposal details...
           </div>
         )}
 

--- a/frontend/src/types/accord.ts
+++ b/frontend/src/types/accord.ts
@@ -14,6 +14,7 @@ export type Proposal = {
   createdAt: string;
   proposer: string;
   userHasApproved: boolean;
+  approverAddresses: string[];
 };
 
 export type Owner = {


### PR DESCRIPTION
## Summary

This PR resolves the issue where the `ApprovalBar` component rendered individual owner approval slots as colored dots without providing any visual feedback on who signed off. 

We added a parallelized on-chain check helper to fetch specific approvers for a proposal, updated the proposal hook data lifecycle, extended the core types, and attached a truncated address tooltip directly to the native HTML `title` attributes of the approved slots.

### Key Changes:
- **`frontend/src/types/accord.ts`**: Added `approverAddresses: string[]` to the `Proposal` type to carry on-chain signer identities.
- **`frontend/src/lib/contract.ts`**: 
  - Added an exported async function `getApprovers(proposalId)` that parallelizes calls to `hasApproved` across all multisig owners.
  - Initialized `approverAddresses: []` within the `mapProposal` transformer to satisfy strict compiler typing.
- **`frontend/src/hooks/useContract.ts`**: Updated the mapping pipeline to resolve and bind the on-chain `approverAddresses` for each proposal inside the core state fetching loop.
- **`frontend/src/components/ApprovalBar.tsx`**: Updated the component to take an optional `approverAddresses` string array prop and added a truncated tooltip format (e.g., `0x1234...abcd`) mapping to the native `title` attribute for active approval slots.
- **`frontend/src/components/ProposalCard.tsx`**: Passed `proposal.approverAddresses` through to `ApprovalBar`.
- **`frontend/src/pages/ProposalDetailPage.tsx` & `frontend/src/App.tsx`**: Cleaned up residual syntax/merge-conflict dead code causing compiler noise during `npm run build`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [x] Refactor

## Related Issue

Closes #2

## Testing Checklist

- [x] Existing tests pass locally
- [ ] New tests added to cover this change (where applicable)
- [x] Manually verified the change works as expected
- [x] Lint / type checks pass