### PR TITLE
feat grant management

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -6,3 +6,7 @@ Beginner-friendly guides for using Accord Protocol.
 |-------|-------------|
 | [Connecting Your Wallet](connecting-your-wallet.md) | Install Freighter, create a Stellar account, switch to Testnet, and fund with test XLM |
 | [Reading the Dashboard](reading-the-dashboard.md) | Understand proposal cards, status badges, the approval bar, and owner vs read-only roles |
+| [Setting Up a Team Multisig](team-multisig.md) | Initialize a 3-of-5 multisig, choose a threshold, and submit your first proposal |
+| [Payroll Multisig](payroll-multisig.md) | Pay contributors monthly in USDC through a 2-of-3 multisig |
+| [Grant Management](grant-management.md) | Disburse USDC grants through a multisig with a grants committee |
+| [Troubleshooting](troubleshooting.md) | Diagnose wallet, transaction, and network errors |

--- a/docs/guides/grant-management.md
+++ b/docs/guides/grant-management.md
@@ -1,0 +1,90 @@
+# Managing Grant Disbursements
+
+This guide walks through a real-world scenario: a three-person grants committee uses a 2-of-3 Accord multisig to disburse USDC to approved applicants. Because the approval threshold is two, no single committee member can release funds alone — every payment requires independent sign-off from at least two of the three members.
+
+---
+
+## Preparing a Grant Round
+
+Before creating any disbursement proposals, confirm that the contract holds enough USDC to cover every approved grant in the current round.
+
+1. Open the Accord dashboard and check the contract's USDC balance displayed at the top of the page.
+2. Compare that balance to the total amount you plan to disburse. If the balance is too low, transfer additional USDC to the contract address before proceeding.
+3. Decide on a naming convention for the round. A clear convention makes it easy to search and audit later. For example, use the format **"Round 3 — Project Aurora — alice.stellar"** so that every proposal description includes the grant reference number, the project name, and the recipient.
+
+> **Tip:** Preparing a spreadsheet of approved grants — with recipient addresses, amounts, and reference numbers — before you start creating proposals helps avoid data-entry mistakes and keeps the round moving quickly.
+
+---
+
+## Creating a Disbursement Proposal
+
+For each approved grant, one committee member creates a proposal in the Accord dashboard. Here is what each field means and how to fill it in:
+
+**Token** — Select the USDC token. The dashboard will show the token symbol so you can verify you are not accidentally selecting a different asset.
+
+**Amount** — Enter the amount in the token's smallest unit (stroops). For USDC on Stellar, 1 USDC equals 10,000,000 stroops. For example, a 500 USDC grant is entered as `5000000000`. The dashboard converts this to a human-readable value on the proposal card so reviewers can double-check.
+
+**Recipient address** — Paste the Stellar address of the grantee. This is a `G…` public key. Always copy it directly from your grants spreadsheet or the applicant's submitted information — never type it by hand.
+
+**Description** — Write a short note that identifies the grantee, the grant round, and any reference number. For example:
+
+> Round 3 — Project Aurora — GCRR…XYZQ
+
+The description field accepts up to 300 characters, which is enough for a reference number, a project name, and a short note. Keep it concise so reviewers can scan it quickly.
+
+**Deadline** — Set a deadline that gives all committee members enough time to review the proposal. Two weeks from today is a reasonable default for most grant rounds. The deadline must be in the future and cannot be more than 90 days out.
+
+**Example proposal:**
+
+| Field | Value |
+|-------|-------|
+| Token | USDC |
+| Amount | `5000000000` (500 USDC) |
+| Recipient | `GCRR…XYZQ` (Alice, Project Aurora) |
+| Description | Round 3 — Project Aurora — GCRR…XYZQ |
+| Deadline | 14 days from now |
+
+After submitting, the dashboard assigns a proposal ID and the proposal appears in the list with a **Pending** status badge.
+
+---
+
+## Reviewing and Approving
+
+Each committee member should independently review the proposal before approving. Rubber-stamping defeats the purpose of a multisig — the whole point is that two people verify every payment.
+
+**What to check before approving:**
+
+1. **Recipient address** — Does the `G…` address on the proposal match the address in your grants spreadsheet? Compare at least the first and last eight characters.
+2. **Amount** — Does the human-readable amount shown on the proposal card match the approved grant amount? A misplaced zero is the most common data-entry error.
+3. **Token symbol** — Confirm the token is USDC. If someone accidentally created the proposal with a different token, reject it and ask the proposer to create a new one.
+4. **Description** — Does the description identify the correct grantee and round? If the description is vague or missing the reference number, ask the proposer to cancel and re-create with a clearer note.
+
+**How to approve:**
+
+1. Open the proposal detail page in the Accord dashboard.
+2. Click **Approve**. Freighter will ask you to sign the transaction.
+3. After signing, your approval is recorded on-chain and the approval bar on the proposal card updates.
+
+Once two of the three committee members have approved, the proposal status changes from **Pending** to **Ready** and the Execute button becomes available.
+
+---
+
+## Completing the Disbursement
+
+Once a proposal reaches the **Ready** status, any committee member can execute it.
+
+1. Open the proposal detail page.
+2. Click **Execute**. Freighter will ask you to sign the execution transaction.
+3. After signing, the USDC is transferred from the contract to the recipient's address. The proposal status changes to **Executed** and no further action is possible.
+
+**Important:** If the deadline passes before anyone clicks Execute, the proposal expires and the funds remain in the contract. You would need to create a new proposal to retry the disbursement. Set your deadlines with enough buffer to avoid this.
+
+If the contract does not hold enough USDC to cover the transfer at execution time, the transaction will fail with a `TransferFailed` error. Top up the contract's USDC balance and try executing again.
+
+---
+
+## What's Next
+
+- **Running recurring disbursements?** See the [Payroll Multisig](payroll-multisig.md) guide for guidance on managing repeated payment cycles — the same pattern applies to quarterly or monthly grant rounds.
+- **Hitting errors?** See the [Troubleshooting](troubleshooting.md) guide for help with common wallet, transaction, and network issues.
+- **Need the full API details?** See the [Contract API Reference](../CONTRACT_API.md) for every function signature, parameter constraint, and error code.

--- a/docs/guides/payroll-multisig.md
+++ b/docs/guides/payroll-multisig.md
@@ -1,0 +1,100 @@
+# Running Payroll Through a Multisig
+
+This guide shows how a team uses Accord Protocol as a payroll system. The scenario: a team pays two contributors monthly in USDC through a 2-of-3 multisig, so that no single person can move funds alone. Each pay period, the team creates a proposal for each contributor, collects two approvals, and executes the transfer before the deadline.
+
+---
+
+## Before You Start
+
+Make sure the following are already in place before your first pay run:
+
+- **The multisig is initialized.** The contract has been deployed and the three owner addresses have been registered with a threshold of 2. If you have not done this yet, see the [Connecting Your Wallet](connecting-your-wallet.md) guide for wallet setup, and the [Reading the Dashboard](reading-the-dashboard.md) guide for an overview of the Accord interface.
+- **All three owners have Freighter on Testnet.** Each owner must have the Freighter browser extension installed, set to the Stellar Testnet network, and funded with test XLM for transaction fees.
+- **The contract holds enough USDC.** Check the contract's USDC balance on the dashboard before creating proposals. The balance must cover at least one full pay run — that is, the sum of all contributor payments for the current period.
+
+---
+
+## Creating the Monthly Proposal
+
+At the start of each pay cycle, one owner creates a payment proposal for each contributor. Here is how to fill in the fields for a single contributor:
+
+**Token** — Select USDC. The dashboard displays the token symbol on the proposal card so reviewers can confirm the correct asset at a glance.
+
+**Amount** — Enter the amount in stroops (the token's smallest unit). For USDC on Stellar, 1 USDC equals 10,000,000 stroops. For example, a 2,000 USDC monthly payment is entered as `20000000000`.
+
+**Recipient address** — Paste the contributor's Stellar address (a `G…` public key). Copy it from your payroll records rather than typing it by hand to avoid mistakes.
+
+**Description** — Write a short note that identifies the contributor and the pay period. For example:
+
+> June 2025 — Alice
+
+The description field accepts up to 300 characters. Keep it short and consistent so that anyone reviewing the proposal list can immediately see who is being paid and for which period.
+
+**Deadline** — Set the deadline roughly two weeks from the proposal creation date. This gives all owners enough time to review and approve, even if someone is travelling or unavailable for a few days. The deadline must be in the future and cannot be more than 90 days out.
+
+**Example proposals for a two-person team:**
+
+| Contributor | Amount | Description | Deadline |
+|-------------|--------|-------------|----------|
+| Alice (`GALC…AAAA`) | `20000000000` (2,000 USDC) | June 2025 — Alice | 14 days from now |
+| Bob (`GBOB…BBBB`) | `15000000000` (1,500 USDC) | June 2025 — Bob | 14 days from now |
+
+After submitting each proposal, the dashboard assigns a proposal ID and the proposal appears with a **Pending** status badge.
+
+---
+
+## Collecting Approvals
+
+Each of the two required owners opens the proposal in the Accord dashboard and approves it independently from their own Freighter wallet.
+
+1. The first owner opens the proposal detail page, verifies the recipient address, amount, and description, then clicks **Approve** and signs the transaction in Freighter.
+2. The second owner repeats the same steps from their own browser and wallet.
+3. Once two approvals are recorded, the proposal status changes from **Pending** to **Ready** and the Execute button becomes available.
+
+**What if an owner is unavailable before the deadline?**
+
+In a 2-of-3 setup, only two of the three owners need to approve. If one owner is on leave or unresponsive, the other two can still approve and execute the proposal. This is one of the main advantages of a 2-of-3 threshold over a 3-of-3 threshold — a single absent owner cannot block payroll.
+
+If two owners are unavailable and the deadline is approaching, the remaining owner cannot execute alone. In this case, wait for at least one other owner to return, or — if the deadline passes — create a new proposal with a longer deadline once the team is available again.
+
+---
+
+## Executing the Transfer
+
+Once the proposal has reached the **Ready** status (meaning the approval threshold has been met), any owner can execute it.
+
+1. Open the proposal detail page.
+2. Click **Execute**. Freighter will prompt you to sign the execution transaction.
+3. After signing, the USDC is transferred from the contract to the contributor's address. The proposal status changes to **Executed**.
+
+**Important:** Execution will fail if the deadline has already passed. The contract checks the current ledger timestamp against the proposal deadline at execution time. If the deadline has expired, the proposal is marked as **Expired** and cannot be executed — you will need to create a new proposal. Always execute promptly once the threshold is met.
+
+---
+
+## Running the Next Pay Cycle
+
+Accord does not have automatic recurrence. There is no built-in scheduler or recurring-payment feature in the contract. Each pay period requires a new proposal for each contributor.
+
+To keep payroll running smoothly:
+
+1. **Pick a consistent creation day.** For example, create all proposals on the last business day of the month for the following month's pay. This sets a predictable rhythm for the team.
+2. **Repeat the process.** Create a new proposal for each contributor, collect two approvals, and execute. The steps are identical every cycle.
+3. **Archive completed cycles.** Keep a note of which proposal IDs correspond to which pay periods. This makes it easy to audit payment history later.
+
+---
+
+## Tips for Reliable Payroll
+
+**Set the deadline far enough in advance.** A two-week window is a reasonable default, but if your team spans multiple time zones or if owners travel frequently, consider a three- or four-week window. This gives a buffer for sick days, holidays, and unexpected absences. Remember that the maximum deadline is 90 days from the time of creation.
+
+**Keep a simple off-chain log.** Maintain a spreadsheet or shared document that maps each proposal ID to the contributor name, amount, and pay period. The on-chain description field is limited to 300 characters, so an off-chain record is useful for longer notes, receipts, and audit trails.
+
+**Prefer a 2-of-3 threshold over 3-of-3.** A 3-of-3 threshold means every single owner must approve every proposal. If one owner is on vacation, sick, or simply slow to respond, payroll is blocked. A 2-of-3 threshold ensures that one absent owner cannot delay payments while still requiring independent verification from two people.
+
+---
+
+## What's Next
+
+- **Disbursing grants instead of payroll?** See the [Grant Management](grant-management.md) guide for a walkthrough tailored to grant rounds.
+- **Hitting errors?** See the [Troubleshooting](troubleshooting.md) guide for help with common wallet, transaction, and network issues.
+- **Need the full API details?** See the [Contract API Reference](../CONTRACT_API.md) for every function signature, parameter constraint, and error code.

--- a/docs/guides/team-multisig.md
+++ b/docs/guides/team-multisig.md
@@ -1,0 +1,158 @@
+# Setting Up a Team Multisig
+
+This guide walks five team members through setting up a 3-of-5 Accord multisig from scratch — from collecting wallet addresses to submitting the team's first proposal. By the end, three of the five members must approve any proposal before funds can move, ensuring no single person can release payments alone.
+
+---
+
+## Before You Start
+
+Make sure the following are in place before you begin:
+
+- **Freighter installed and on Testnet.** Every team member needs the Freighter browser extension installed, set to the Stellar Testnet network, and funded with test XLM. See the [Connecting Your Wallet](connecting-your-wallet.md) guide for step-by-step instructions.
+- **All five owner addresses collected.** Gather the Stellar public key (`G…` address) from each team member's Freighter wallet. You will need all five addresses during initialization.
+- **The contract deployed and funded.** The Accord contract must already be deployed to Stellar testnet and the contract address must hold enough tokens to cover your first test transfer. See [docs/DEPLOYMENT.md](../DEPLOYMENT.md) for deployment steps — this guide does not repeat them.
+
+**The five team members used in this guide:**
+
+| Role | Label | Placeholder address |
+|------|-------|---------------------|
+| Team lead | Alice | `GALC…AAAA` |
+| Finance | Bob | `GBOB…BBBB` |
+| Engineering | Carol | `GCAR…CCCC` |
+| Operations | Dave | `GDAV…DDDD` |
+| Advisor | Eve | `GEVE…EEEE` |
+
+These placeholder addresses appear throughout the guide. In your setup, replace them with the real public keys from each team member's Freighter wallet.
+
+---
+
+## Choosing Your Threshold
+
+The threshold is the number of owners who must approve a proposal before it can be executed. For a five-person team, you need to decide how many approvals to require.
+
+**What 3-of-5 means in practice:**
+
+- Any three of the five owners must approve before a proposal can be executed.
+- Two owners can be unavailable (travelling, on leave, unresponsive) and the remaining three can still move funds.
+- If a single private key is compromised, the attacker cannot execute anything alone — they would still need two more approvals from legitimate owners.
+
+**The trade-off: security versus availability.**
+
+A higher threshold is more secure but harder to coordinate:
+
+| Threshold | Security | Availability |
+|-----------|----------|-------------|
+| **2-of-5** | Lower — only two people need to agree, so a compromised key plus one social-engineering attack could release funds. | Higher — easy to get two people online at any time. |
+| **3-of-5** | Balanced — a bare majority must agree, and an attacker would need to compromise three separate keys. | Balanced — works well when at least three members are regularly available. |
+| **4-of-5** | Higher — almost everyone must agree, making unauthorized transfers very difficult. | Lower — if two people are unavailable simultaneously, the team is blocked. |
+| **5-of-5** | Highest — every member must sign. | Lowest — a single absent member blocks all operations. |
+
+**When to choose something other than 3-of-5:**
+
+- Choose **2-of-5** if your team operates across very different time zones and availability is your biggest concern.
+- Choose **4-of-5** if you are managing a high-value treasury and can tolerate slower operations in exchange for stronger security.
+- Avoid **5-of-5** for any team where members may be unavailable — a single absent owner will block every payment.
+
+For most teams, **3-of-5 is the recommended default**. It provides a strong security guarantee while allowing the team to operate even when two members are temporarily unavailable.
+
+---
+
+## Initializing the Multisig
+
+Initialization is a one-time step that registers the owner list and sets the approval threshold. After initialization, the configuration is locked and cannot be changed except through governance proposals.
+
+**How it works:**
+
+1. One team member (typically the person who deployed the contract) submits the initialization transaction through the Accord dashboard or CLI.
+2. The transaction includes the list of all five owner addresses and the chosen threshold (3 in this example).
+3. **Every one of the five owners must approve this transaction from their own Freighter wallet.** This is a security measure — it ensures that no one can be added as an owner without their knowledge and consent. The contract will not store the configuration until all five addresses have authorized.
+
+**The initialization parameters for a 3-of-5 setup:**
+
+| Parameter | Value |
+|-----------|-------|
+| Owners | `GALC…AAAA`, `GBOB…BBBB`, `GCAR…CCCC`, `GDAV…DDDD`, `GEVE…EEEE` |
+| Threshold | `3` |
+| Time-lock delay | `0` (no delay — proposals are executable immediately once the threshold is met) |
+
+**What to expect:**
+
+- The team lead (Alice) submits the initialization transaction.
+- Freighter prompts each of the five owners to review and sign the transaction.
+- Once all five have signed, the contract stores the owner list and threshold on-chain.
+- If any owner declines or is not available to sign, the initialization does not go through. Coordinate with all five members before starting.
+
+**After initialization:**
+
+- The contract accepts proposals from any of the five owners.
+- Any proposal requires three approvals before it can be executed.
+- The owner list and threshold can only be changed through Add Owner, Remove Owner, or Change Threshold governance proposals, which themselves require three approvals to execute.
+
+---
+
+## Verifying the Setup
+
+After initialization, confirm that the on-chain state matches what you intended.
+
+**Check the owner list in the dashboard:**
+
+1. Open the Accord dashboard in your browser.
+2. Navigate to the settings or contract info section.
+3. Verify that all five addresses are listed as owners: `GALC…AAAA`, `GBOB…BBBB`, `GCAR…CCCC`, `GDAV…DDDD`, and `GEVE…EEEE`.
+
+**Check the threshold in the dashboard:**
+
+The dashboard displays the current threshold alongside the owner list. Confirm it shows **3-of-5**.
+
+**View the on-chain state on Stellar Expert (optional):**
+
+Open the following URL in your browser, replacing `YOUR_CONTRACT_ID` with your actual contract ID:
+
+```
+https://stellar.expert/explorer/testnet/contract/YOUR_CONTRACT_ID
+```
+
+This shows the contract's transaction history, including the initialization transaction with all five owner signatures.
+
+If the owner list and threshold both match your intended configuration, the multisig is live and ready to accept proposals.
+
+---
+
+## Submitting the First Proposal
+
+Now that the multisig is initialized, test the full proposal flow by creating a small payment proposal.
+
+**1. Create the proposal.**
+
+One of the five owners opens the Accord dashboard and creates a new payment proposal with the following details:
+
+| Field | Value |
+|-------|-------|
+| Token | USDC (or whichever token the contract holds) |
+| Amount | A small test amount — for example, `10000000` (1 USDC in stroops) |
+| Recipient | A test address outside the multisig (for example, a personal wallet) |
+| Description | Test transfer — first proposal |
+| Deadline | 14 days from now |
+
+After submitting, the proposal appears in the dashboard with a **Pending** status badge and an empty approval bar.
+
+**2. Collect three approvals.**
+
+Three of the five owners each open the proposal in the dashboard, verify the details (recipient, amount, token), and click **Approve**. Each approval is signed independently through the owner's own Freighter wallet.
+
+As each owner approves, the approval bar fills. Once the third approval is recorded, the proposal status changes from **Pending** to **Ready**.
+
+**3. Execute the transfer.**
+
+Any owner can now click **Execute** on the Ready proposal. Freighter prompts the owner to sign the execution transaction. After signing, the tokens are transferred from the contract to the recipient and the proposal status changes to **Executed**.
+
+If all three steps complete successfully, your multisig is fully operational.
+
+---
+
+## What's Next
+
+- **Learn the full approval and execution flow.** See the [Approve and Execute a Proposal](../tutorials/approve-and-execute-a-proposal.md) tutorial for a detailed walkthrough of each step.
+- **Understand proposal statuses.** See the [Understanding Proposal Lifecycle](../tutorials/understanding-proposal-lifecycle.md) reference for how proposals move through Pending, Ready, Executed, and Expired states.
+- **Set up payroll or grant disbursements.** See the [Payroll Multisig](payroll-multisig.md) guide or the [Grant Management](grant-management.md) guide for real-world use cases.
+- **Troubleshoot issues.** See the [Troubleshooting](troubleshooting.md) guide if you encounter wallet, transaction, or network errors.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,0 +1,146 @@
+# Troubleshooting
+
+This guide covers the most common errors you will encounter when using Accord Protocol — from wallet connection issues to on-chain transaction failures and network problems. Each entry explains what the error means, why it happens, and how to fix it.
+
+---
+
+## Wallet Connection Issues
+
+### Freighter not detected
+
+**What you see:** The dashboard shows a prompt asking you to install Freighter, or the Connect Wallet button does nothing.
+
+**Why it happens:** The Freighter browser extension is not installed, is disabled, or your browser does not support it.
+
+**How to fix it:**
+
+1. Open the [Freighter download page](https://www.freighter.app) and install the extension for your browser.
+2. If Freighter is already installed, check that it is enabled. In Chrome, go to **Settings → Extensions** and make sure the Freighter toggle is on.
+3. Restart your browser after installing or re-enabling the extension.
+4. If you are using a browser that does not support extensions (such as Safari on iOS), switch to a desktop browser like Chrome, Firefox, or Brave.
+
+For a full walkthrough, see the [Connecting Your Wallet](connecting-your-wallet.md) guide.
+
+---
+
+### Wallet connected to the wrong network
+
+**What you see:** The dashboard loads but shows no proposals, or you see an error that the contract is not found.
+
+**Why it happens:** Your Freighter wallet is set to **Mainnet** (or another network) while the Accord contract is deployed on **Testnet**.
+
+**How to fix it:**
+
+1. Click the Freighter icon in your browser toolbar.
+2. Look at the network selector at the top of the popup.
+3. Switch it to **Testnet**.
+4. Refresh the Accord dashboard page.
+
+---
+
+### Read-only banner appears for non-owners
+
+**What you see:** The dashboard shows a banner or message indicating you are in read-only mode. You can view proposals but cannot create, approve, or execute them.
+
+**Why it happens:** The wallet address you have connected is not one of the registered owners of the multisig contract. Only addresses that were included in the owner list during contract initialization (or added later via a governance proposal) can perform owner actions.
+
+**How to fix it:**
+
+1. Confirm you are using the correct Freighter account. If you have multiple accounts in Freighter, click the account switcher and select the one that was registered as an owner.
+2. If you believe your address should be an owner, ask an existing owner to verify the owner list in the dashboard. Your address may have been entered incorrectly during initialization.
+3. If you need to be added as an owner, an existing owner must create and execute an Add Owner governance proposal through the dashboard.
+
+---
+
+## Failed Transaction Errors
+
+These errors appear when a transaction is submitted to the Stellar network but is rejected by the Accord smart contract. Freighter will show the error name in the transaction failure message.
+
+### Unauthorized
+
+**What it means:** The wallet address that signed the transaction is not a registered owner of the multisig contract.
+
+**Why it happens:** You are trying to create a proposal, approve, revoke, or execute using a wallet that is not on the owner list. This can also happen if you switched Freighter accounts after loading the dashboard.
+
+**How to fix it:** Switch to the Freighter account that is registered as an owner. If you are unsure which account that is, check the owner list displayed on the dashboard.
+
+---
+
+### ThresholdNotMet
+
+**What it means:** The proposal does not have enough approvals to be executed yet.
+
+**Why it happens:** You clicked Execute on a proposal that is still in **Pending** status. For a 2-of-3 multisig, at least two owners must approve before the proposal can be executed.
+
+**How to fix it:** Wait for more owners to approve the proposal. You can see the current approval count on the proposal's approval bar. Once the bar is full and the status changes to **Ready**, any owner can execute.
+
+---
+
+### ProposalExpired
+
+**What it means:** The proposal's deadline has passed. It can no longer be approved or executed.
+
+**Why it happens:** The team did not collect enough approvals or did not execute the proposal before the deadline. Once the ledger timestamp exceeds the deadline, the contract permanently marks the proposal as expired.
+
+**How to fix it:** Create a new proposal with the same details and set a longer deadline this time. Consider using a two-week or one-month deadline to give all owners enough time to review and approve. The maximum allowed deadline is 90 days from the time of creation.
+
+---
+
+### TooManyActiveProposals
+
+**What it means:** The contract has reached its limit of 50 active proposals (proposals that are in **Pending** or **Ready** status).
+
+**Why it happens:** Too many proposals were created without being executed or cleaned up. The contract enforces a hard cap of 50 active proposals to keep storage costs bounded.
+
+**How to fix it:**
+
+1. Execute any **Ready** proposals that are waiting to be finalized.
+2. Ask an owner to clean up expired proposals using the dashboard's cleanup function. This frees up active-proposal slots by removing proposals whose deadlines have already passed.
+3. After cleanup, try creating your proposal again.
+
+---
+
+## RPC and Network Problems
+
+### Dashboard shows a loading spinner indefinitely
+
+**What you see:** The Accord dashboard stays on a loading state and never displays proposals or contract data.
+
+**Why it happens:** The dashboard cannot reach the Soroban RPC endpoint. This could be because the RPC server is down, your internet connection is interrupted, or the RPC URL in the application configuration is incorrect.
+
+**How to fix it:**
+
+1. Check your internet connection by opening another website.
+2. Refresh the dashboard page. Transient network issues often resolve on a retry.
+3. If the problem persists, the RPC endpoint may be experiencing downtime. Try switching to a backup RPC endpoint (see below).
+
+---
+
+### Switching to a backup RPC endpoint
+
+If the default RPC endpoint is unresponsive, you can point the Accord frontend at a different Soroban RPC server.
+
+1. Open the environment configuration file for the frontend. If you are running the app locally, this is `frontend/.env.local`. See [Development Setup](../SETUP.md) for details on the configuration file.
+2. Find the `VITE_SOROBAN_RPC_URL` variable (or the equivalent RPC URL setting).
+3. Replace the current URL with a working Soroban RPC endpoint. Community-run endpoints and lists of public RPC nodes can be found on the [Stellar Developers site](https://developers.stellar.org).
+4. Save the file and restart the frontend dev server, or redeploy if you are running a production build.
+
+---
+
+### Checking the Stellar Testnet status
+
+If you suspect the problem is with the Stellar Testnet itself rather than a single RPC node, check the network status:
+
+1. Visit the [Stellar Dashboard](https://dashboard.stellar.org) to see the current health of the public Stellar networks, including Testnet.
+2. Look for any ongoing incidents or degraded performance notices.
+3. If Testnet is down, you will need to wait for the Stellar Development Foundation to restore it. Testnet outages are usually resolved within a few hours.
+
+---
+
+## What's Next
+
+- **Setting up your wallet for the first time?** See the [Connecting Your Wallet](connecting-your-wallet.md) guide.
+- **Learning what each part of the dashboard means?** See the [Reading the Dashboard](reading-the-dashboard.md) guide.
+- **Managing grant disbursements?** See the [Grant Management](grant-management.md) guide.
+- **Running payroll through Accord?** See the [Payroll Multisig](payroll-multisig.md) guide.
+- **Need the full list of error codes?** See the [Contract API Reference](../CONTRACT_API.md) for every error code, its numeric value, and when it is thrown.

--- a/docs/tutorials/deploy-your-own-multisig.md
+++ b/docs/tutorials/deploy-your-own-multisig.md
@@ -1,0 +1,233 @@
+# Deploy Your Own Multisig
+
+## What You Will Build
+
+By the end of this tutorial you will have a working 2-of-3 Accord multisig contract deployed to the Stellar testnet. The contract will be initialized with three owner addresses and a threshold of two, meaning any two of the three owners must approve a proposal before it can be executed. You will verify the deployment by querying the on-chain state to confirm that the owner list and threshold match what you configured.
+
+---
+
+## Prerequisites
+
+Before you begin, make sure you have the following installed and working. If anything is missing, follow the linked setup instructions — this tutorial will not repeat them.
+
+| Requirement | How to check | Install instructions |
+|-------------|--------------|----------------------|
+| **Git** | `git --version` | [git-scm.com](https://git-scm.com) |
+| **Rust** (stable) with the `wasm32v1-none` target | `rustc --version` and `rustup target list --installed` | [docs/SETUP.md — Install Rust](../SETUP.md#1-install-rust) |
+| **Stellar CLI** | `stellar --version` | [docs/SETUP.md — Install Stellar CLI](../SETUP.md#2-install-stellar-cli) |
+| **A funded testnet identity** | `stellar keys public-key accord-deployer` | Created in the next section if you don't have one |
+
+---
+
+## Clone and Build
+
+Start by cloning the Accord repository and building the contract.
+
+**1. Clone the repository:**
+
+```bash
+git clone https://github.com/thegreatfeez/accord-protocol.git
+cd accord-protocol
+```
+
+**2. Build the contract WASM:**
+
+```bash
+stellar contract build
+```
+
+This compiles the Soroban smart contract and produces a WASM binary. When the build finishes, the compiled file will be at:
+
+```
+target/wasm32v1-none/release/accord.wasm
+```
+
+You can confirm the file exists:
+
+```bash
+ls -lh target/wasm32v1-none/release/accord.wasm
+```
+
+If the build fails with a "wasm32v1-none target not found" error, you need to add the target to your Rust toolchain:
+
+```bash
+rustup target add wasm32v1-none
+```
+
+Then run `stellar contract build` again.
+
+---
+
+## Create a Testnet Identity and Fund It
+
+You need a Stellar identity (keypair) to sign deployment transactions. If you already have an `accord-deployer` identity, skip to the funding step.
+
+**1. Generate a named keypair:**
+
+```bash
+stellar keys generate accord-deployer
+```
+
+This creates a new Stellar keypair stored locally under the name `accord-deployer`. Print the public key to confirm it was created:
+
+```bash
+stellar keys public-key accord-deployer
+```
+
+You should see a `G…` address printed to the terminal.
+
+**2. Switch the CLI to testnet:**
+
+```bash
+stellar network use testnet
+```
+
+**3. Fund the account via Friendbot:**
+
+The repository includes a convenience script that funds an account through Stellar's Friendbot faucet:
+
+```bash
+bash scripts/fund-account.sh accord-deployer
+```
+
+The script will print the public key and a link to view the account on Stellar Expert. Friendbot credits the account with 10,000 test XLM — more than enough for deploying and interacting with the contract.
+
+If Friendbot returns an error saying the account is already funded, that is fine — your account already has XLM and you can proceed.
+
+---
+
+## Deploy the Contract
+
+You have two options: the `deploy.sh` convenience script, or the manual CLI commands. Both produce the same result — a live contract instance on testnet with a Contract ID printed to your terminal.
+
+### Option A — Use the deploy script
+
+From the repository root:
+
+```bash
+bash scripts/deploy.sh
+```
+
+The script does three things in sequence:
+
+1. Builds the contract WASM (so you can skip the earlier build step if you go straight here).
+2. Uploads the WASM to the Stellar testnet.
+3. Deploys a new contract instance and prints the **Contract ID**.
+
+The output will look something like this:
+
+```
+==========================================
+  Contract deployed successfully!
+  Contract ID: CABC...XYZ123
+  Network: testnet
+==========================================
+```
+
+Copy the Contract ID and save it somewhere safe — you will need it for every subsequent step.
+
+### Option B — Manual CLI commands
+
+If you prefer to run each step yourself, or if you need to customize the identity or network, use these commands:
+
+```bash
+stellar network use testnet
+
+# Upload the WASM to the network
+stellar contract upload \
+  --network testnet \
+  --source-account accord-deployer \
+  --wasm target/wasm32v1-none/release/accord.wasm
+
+# Deploy a new contract instance
+stellar contract deploy \
+  --network testnet \
+  --source-account accord-deployer \
+  --wasm target/wasm32v1-none/release/accord.wasm
+```
+
+The `deploy` command prints the Contract ID. Copy and save it.
+
+---
+
+## Initialize the Contract
+
+Deploying the contract creates an empty instance on the network. You now need to initialize it with your list of owners and an approval threshold.
+
+For this tutorial, you will set up a 2-of-3 multisig with three owner addresses. Replace the placeholder addresses below with real Stellar public keys — these are the wallets that will control the multisig.
+
+```bash
+stellar contract invoke \
+  --network testnet \
+  --source-account accord-deployer \
+  --id YOUR_CONTRACT_ID \
+  -- initialize \
+  --owners '["GALICE0000000000000000000000000000000000000000000AAAA","GBOBBB0000000000000000000000000000000000000000000BBBB","GCHARLIE00000000000000000000000000000000000000000CCCC"]' \
+  --threshold 2 \
+  --time_lock_delay 0
+```
+
+**What each argument means:**
+
+| Argument | Value | Purpose |
+|----------|-------|---------|
+| `--id` | Your Contract ID | The contract you just deployed |
+| `--owners` | JSON array of three `G…` addresses | The Stellar accounts that will control this multisig |
+| `--threshold` | `2` | The number of approvals required to execute any proposal |
+| `--time_lock_delay` | `0` | Seconds to wait after threshold is met before execution is allowed (0 means no delay) |
+
+**Important:** The `initialize` function requires authorization from every owner in the list, not just the deployer. When initializing via the CLI, the `--source-account` signs as one of the owners. For a production setup, the other owners would authorize the transaction through their own wallets (typically via the Accord frontend). On testnet, if you control all three keypairs locally, you can initialize directly from the CLI.
+
+The command prints no output on success. If you see an `AlreadyInitialized` error, the contract has already been initialized and you can move on to verification.
+
+---
+
+## Verify the Deployment
+
+Confirm that the on-chain state matches what you configured during initialization.
+
+**1. Check the owner list:**
+
+```bash
+stellar contract invoke \
+  --network testnet \
+  --source-account accord-deployer \
+  --id YOUR_CONTRACT_ID \
+  -- get_owners
+```
+
+This returns a JSON array of the three owner addresses you provided. Verify that all three addresses are present and correct.
+
+**2. Check the threshold:**
+
+```bash
+stellar contract invoke \
+  --network testnet \
+  --source-account accord-deployer \
+  --id YOUR_CONTRACT_ID \
+  -- get_threshold
+```
+
+This returns `2` — confirming that two out of three owners must approve before any proposal can be executed.
+
+**3. View the contract on Stellar Expert (optional):**
+
+Open the following URL in your browser, replacing `YOUR_CONTRACT_ID` with your actual contract ID:
+
+```
+https://stellar.expert/explorer/testnet/contract/YOUR_CONTRACT_ID
+```
+
+This shows the contract's on-chain state, transaction history, and WASM hash.
+
+If both `get_owners` and `get_threshold` return the values you expect, your multisig is live and ready to use.
+
+---
+
+## Next Steps
+
+Your multisig contract is deployed and initialized. Here is where to go from here:
+
+- **Create your first proposal.** Head to the [user guides](../guides/) to learn how to create a payment proposal, collect approvals, and execute a transfer through the Accord dashboard.
+- **Set up the frontend.** Add your Contract ID to `frontend/.env.local` and start the dev server — see [docs/DEPLOYMENT.md](../DEPLOYMENT.md#5-wire-the-frontend) for the configuration variables.
+- **Plan for mainnet.** When you are ready to deploy to production, review [docs/DEPLOYMENT.md](../DEPLOYMENT.md) for mainnet deployment considerations, contract upgrades, and post-deployment verification checklists.


### PR DESCRIPTION
Closes #155
Closes #156
Closes #157
Closes #158

## Files Created

| File | Description |
|------|-------------|
| [grant-management.md](file:///Users/marvellous/Desktop/AccordProtocol-1/docs/guides/grant-management.md) | Grant disbursement walkthrough (90 lines) |
| [troubleshooting.md](file:///Users/marvellous/Desktop/AccordProtocol-1/docs/guides/troubleshooting.md) | Troubleshooting reference (146 lines) |
| [payroll-multisig.md](file:///Users/marvellous/Desktop/AccordProtocol-1/docs/guides/payroll-multisig.md) | Payroll multisig guide (100 lines) |

## File Updated

| File | Change |
|------|--------|
| [README.md](file:///Users/marvellous/Desktop/AccordProtocol-1/docs/guides/README.md) | Added all three new guides to the index table |

## Acceptance Criteria Checklist

| Criteria | Status |
|----------|--------|
| `grant-management.md` exists and renders as Markdown | ✅ |
| Grant guide uses consistent 2-of-3 example with labelled placeholder addresses | ✅ (`GCRR…XYZQ`, `GALC…AAAA`, `GBOB…BBBB`) |
| `troubleshooting.md` exists and renders as Markdown | ✅ |
| Troubleshooting covers Unauthorized, ThresholdNotMet, ProposalExpired, TooManyActiveProposals with cause & fix | ✅ |
| Troubleshooting has dedicated RPC/network section | ✅ |
| `payroll-multisig.md` exists and renders as Markdown | ✅ |
| Payroll guide uses consistent 2-of-3 example with labelled addresses | ✅ |
| Deadline constraint documented (future, max 90 days) | ✅ |
| "Running the Next Pay Cycle" states no automatic recurrence | ✅ |
| Payroll guide links to other guides (not repeating setup steps) | ✅ |
| No command-line flags or Rust code in any guide | ✅ |
| All guides end with "What's Next" sections cross-linking each other | ✅ |
## Summary

### Files Created

| File | Lines | Description |
|------|-------|-------------|
| [deploy-your-own-multisig.md](file:///Users/marvellous/Desktop/AccordProtocol-1/docs/tutorials/deploy-your-own-multisig.md) | 233 | End-to-end tutorial: empty machine → live 2-of-3 multisig on testnet |
| [team-multisig.md](file:///Users/marvellous/Desktop/AccordProtocol-1/docs/guides/team-multisig.md) | 158 | Guide: five team members set up a 3-of-5 multisig and submit their first proposal |

### File Updated

| File | Change |
|------|--------|
| [README.md](file:///Users/marvellous/Desktop/AccordProtocol-1/docs/guides/README.md) | Added team-multisig to the guides index table |

### Acceptance Criteria — Deploy Tutorial

| Criteria | ✓ |
|----------|---|
| Covers all steps from `git clone` to verified live contract | ✅ |
| Opens with "What you will build" + prerequisites checklist | ✅ |
| Every shell command shown verbatim, including `initialize` with placeholder addresses and threshold 2 | ✅ |
| Deploy section documents both `scripts/deploy.sh` and manual CLI commands | ✅ |
| Verify section shows `get_owners` and `get_threshold` read calls | ✅ |
| "Next steps" section links to related docs | ✅ |

### Acceptance Criteria — Team Multisig Guide

| Criteria | ✓ |
|----------|---|
| Uses consistent 3-of-5 example with five labelled placeholder addresses | ✅ |
| States all five owners must sign initialization (not just deployer) | ✅ |
| Links to `docs/DEPLOYMENT.md` for deploy steps | ✅ |
| "Choosing Your Threshold" explains security-vs-availability trade-off | ✅ |
| No CLI flags or Rust code | ✅ |
| "What's Next" links to approval/lifecycle tutorials | ✅ |