### PR TITLE
feat(accord): add guardian role with freeze/unfreeze controls

### DIFF
--- a/contracts/accord/src/lib.rs
+++ b/contracts/accord/src/lib.rs
@@ -89,6 +89,24 @@ pub struct ProposalExecutedEvent {
     pub executor: Address,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct GuardianSetEvent {
+    pub guardian: Address,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct FrozenEvent {
+    pub guardian: Address,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct UnfrozenEvent {
+    pub approvers: Vec<Address>,
+}
+
 // ─── Errors ──────────────────────────────────────────────────────────────────
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -120,6 +138,8 @@ pub enum ContractError {
     TimeLockActive = 23,
     WouldBreakThreshold = 24,
     OwnerNotFound = 25,
+    ContractFrozen = 26,
+    NoGuardian = 27,
 }
 
 // ─── Storage Keys ────────────────────────────────────────────────────────────
@@ -154,6 +174,14 @@ fn active_count_key() -> Symbol {
 
 fn timelock_key() -> Symbol {
     symbol_short!("TLOCK")
+}
+
+fn guardian_key() -> Symbol {
+    symbol_short!("GUARD")
+}
+
+fn frozen_key() -> Symbol {
+    symbol_short!("FROZEN")
 }
 
 // ─── TTL Constants ───────────────────────────────────────────────────────────
@@ -301,6 +329,34 @@ fn write_active_count(env: &Env, count: u32) {
     bump_instance(env);
 }
 
+fn read_guardian(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&guardian_key())
+}
+
+fn write_guardian(env: &Env, guardian: &Address) {
+    env.storage().instance().set(&guardian_key(), guardian);
+    bump_instance(env);
+}
+
+fn is_frozen_state(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get::<_, bool>(&frozen_key())
+        .unwrap_or(false)
+}
+
+fn write_frozen(env: &Env, frozen: bool) {
+    env.storage().instance().set(&frozen_key(), &frozen);
+    bump_instance(env);
+}
+
+fn require_not_frozen(env: &Env) -> Result<(), ContractError> {
+    if is_frozen_state(env) {
+        return Err(ContractError::ContractFrozen);
+    }
+    Ok(())
+}
+
 // ─── Business Logic Helpers ──────────────────────────────────────────────────
 
 fn require_owner(env: &Env, address: &Address) -> Result<(), ContractError> {
@@ -423,6 +479,7 @@ impl AccordContract {
     ) -> Result<u64, ContractError> {
         proposer.require_auth();
         require_owner(&env, &proposer)?;
+        require_not_frozen(&env)?;
 
         if amount < MIN_AMOUNT {
             return Err(ContractError::InvalidAmount);
@@ -496,6 +553,7 @@ impl AccordContract {
     ) -> Result<u64, ContractError> {
         proposer.require_auth();
         require_owner(&env, &proposer)?;
+        require_not_frozen(&env)?;
 
         let owners = read_owners(&env)?;
         for owner in owners.iter() {
@@ -576,6 +634,7 @@ impl AccordContract {
     ) -> Result<u64, ContractError> {
         proposer.require_auth();
         require_owner(&env, &proposer)?;
+        require_not_frozen(&env)?;
 
         let owners = read_owners(&env)?;
         let threshold = read_threshold(&env)?;
@@ -661,6 +720,7 @@ impl AccordContract {
     ) -> Result<u64, ContractError> {
         proposer.require_auth();
         require_owner(&env, &proposer)?;
+        require_not_frozen(&env)?;
 
         let owners = read_owners(&env)?;
 
@@ -838,6 +898,7 @@ impl AccordContract {
     ) -> Result<(), ContractError> {
         executor.require_auth();
         require_owner(&env, &executor)?;
+        require_not_frozen(&env)?;
 
         let mut proposal = read_proposal(&env, proposal_id)?;
 
@@ -1047,6 +1108,112 @@ impl AccordContract {
     /// Returns whether `owner` has approved `proposal_id`.
     pub fn has_approved(env: Env, proposal_id: u64, owner: Address) -> bool {
         read_approval(&env, proposal_id, &owner)
+    }
+
+    // ─── Guardian ─────────────────────────────────────────────────────────────
+
+    /// Assigns or replaces the guardian address. Requires at least `threshold`
+    /// distinct owners in `approvers` to co-sign, preventing any single owner
+    /// from installing a guardian unilaterally.
+    pub fn set_guardian(
+        env: Env,
+        approvers: Vec<Address>,
+        new_guardian: Address,
+    ) -> Result<(), ContractError> {
+        let threshold = read_threshold(&env)?;
+
+        if approvers.len() < threshold {
+            return Err(ContractError::ThresholdNotMet);
+        }
+
+        for i in 0..approvers.len() {
+            for j in (i + 1)..approvers.len() {
+                if approvers.get(i).unwrap() == approvers.get(j).unwrap() {
+                    return Err(ContractError::DuplicateOwner);
+                }
+            }
+        }
+
+        for approver in approvers.iter() {
+            approver.require_auth();
+            require_owner(&env, &approver)?;
+        }
+
+        write_guardian(&env, &new_guardian);
+
+        env.events().publish(
+            (symbol_short!("guard_set"),),
+            GuardianSetEvent {
+                guardian: new_guardian,
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Immediately freezes the contract, blocking new proposals and execution.
+    /// Only the current guardian may call this.
+    pub fn freeze(env: Env, guardian: Address) -> Result<(), ContractError> {
+        guardian.require_auth();
+
+        let stored = read_guardian(&env).ok_or(ContractError::NoGuardian)?;
+        if stored != guardian {
+            return Err(ContractError::Unauthorized);
+        }
+
+        write_frozen(&env, true);
+
+        env.events().publish(
+            (symbol_short!("frozen"),),
+            FrozenEvent { guardian },
+        );
+
+        Ok(())
+    }
+
+    /// Resumes normal operation after a freeze. Requires at least `threshold`
+    /// distinct owners in `approvers` to co-sign, so no individual can thaw a
+    /// frozen contract alone.
+    pub fn unfreeze(env: Env, approvers: Vec<Address>) -> Result<(), ContractError> {
+        let threshold = read_threshold(&env)?;
+
+        if approvers.len() < threshold {
+            return Err(ContractError::ThresholdNotMet);
+        }
+
+        for i in 0..approvers.len() {
+            for j in (i + 1)..approvers.len() {
+                if approvers.get(i).unwrap() == approvers.get(j).unwrap() {
+                    return Err(ContractError::DuplicateOwner);
+                }
+            }
+        }
+
+        for approver in approvers.iter() {
+            approver.require_auth();
+            require_owner(&env, &approver)?;
+        }
+
+        write_frozen(&env, false);
+
+        env.events().publish(
+            (symbol_short!("unfrozen"),),
+            UnfrozenEvent {
+                approvers: approvers.clone(),
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Returns whether the contract is currently frozen.
+    pub fn is_frozen(env: Env) -> bool {
+        is_frozen_state(&env)
+    }
+
+    /// Returns the current guardian address, or `None` if no guardian is set.
+    pub fn get_guardian(env: Env) -> Option<Address> {
+        read_guardian(&env)
     }
 
     // ─── Upgrade ─────────────────────────────────────────────────────────────

--- a/contracts/accord/test_snapshots/test/active_count_stays_accurate_after_execute.1.json
+++ b/contracts/accord/test_snapshots/test/active_count_stays_accurate_after_execute.1.json
@@ -2265,6 +2265,7 @@
         }
       ]
     ],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
@@ -2331,6 +2332,7 @@
         }
       ]
     ],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",

--- a/contracts/accord/test_snapshots/test/active_count_stays_accurate_after_expire.1.json
+++ b/contracts/accord/test_snapshots/test/active_count_stays_accurate_after_expire.1.json
@@ -2201,6 +2201,8 @@
     [],
     [],
     [],
+    [],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",

--- a/contracts/accord/test_snapshots/test/active_count_stays_accurate_mixed.1.json
+++ b/contracts/accord/test_snapshots/test/active_count_stays_accurate_mixed.1.json
@@ -2265,6 +2265,7 @@
         }
       ]
     ],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
@@ -2306,6 +2307,7 @@
         }
       ]
     ],
+    [],
     [],
     [
       [


### PR DESCRIPTION
Closes #204 
Closes #205 
Closes #206

Summary
Guardian role — a designated address (set_guardian, requires threshold of owners) that can call freeze() to instantly block all create_* and execute operations
unfreeze(approvers) — requires threshold of owner co-signatures to resume, preventing any single party from thawing alone
is_frozen() / get_guardian() — read-only queries for frontends and monitoring tools
ContractFrozen (26) and NoGuardian (27) added to the error enum; GuardianSetEvent, FrozenEvent, UnfrozenEvent emitted on state transitions
approve(), revoke(), cancel_expired(), and upgrade() are intentionally not blocked during a freeze — owners can keep signing and can still upgrade out of a bad state
Note: get_approvers (item 2 in the issue) already exists in the contract at [lib.rs:973–984](vscode-webview://1mjd6kh9ht1232uugr169v12k2s87k2pog2stbqb68uj51ri3dbf/contracts/accord/src/lib.rs#L973-L984) — it iterates all current owners and returns those with an active approval. No additional work needed there.

Test plan
 set_guardian succeeds with threshold owners, fails with fewer
 freeze succeeds when called by the stored guardian, reverts with Unauthorized for any other address
 create_proposal and execute return ContractFrozen while frozen
 approve and revoke still succeed while frozen
 unfreeze succeeds with threshold owners and resumes normal operation
 get_guardian returns None before set and the correct address after
 is_frozen reflects state changes accurately