### PR TITLE
Resolve issues #127 #132 #129 #128

### DIFF
--- a/docs/CONTRACT_API.md
+++ b/docs/CONTRACT_API.md
@@ -194,31 +194,39 @@ Returns `true` if `owner` has approved `proposal_id`.
 
 ---
 
-## Error Codes
+## Error Reference
 
-| Code | Value | Meaning |
-|------|-------|---------|
-| `AlreadyInitialized` | 1 | `initialize` was already called |
-| `NotInitialized` | 2 | Contract has not been initialized |
-| `Unauthorized` | 3 | Caller is not an owner |
-| `InvalidThreshold` | 4 | threshold = 0 or threshold > owner count |
-| `InvalidOwners` | 5 | Empty or oversized owner list |
-| `ProposalNotFound` | 6 | No proposal exists with that ID |
-| `ProposalNotActive` | 7 | Proposal is Executed, Expired, or Revoked |
-| `AlreadyApproved` | 8 | Owner already approved this proposal |
-| `NotApproved` | 9 | Owner has not approved — cannot revoke |
-| `ThresholdNotMet` | 10 | Approvals < threshold — cannot execute |
-| `ProposalExpired` | 11 | Deadline has passed |
-| `InvalidAmount` | 12 | Amount < 1 |
-| `InvalidDeadline` | 13 | Deadline ≤ current ledger timestamp |
-| `InvalidToken` | 14 | Token address does not implement Soroban token interface |
-| `TransferFailed` | 15 | On-chain token transfer failed (check contract balance) |
-| `EmptyDescription` | 16 | Description is empty |
-| `DescriptionTooLong` | 17 | Description exceeds 300 characters |
-| `TooManyActiveProposals` | 18 | Active proposal count reached limit (50) |
-| `DuplicateOwner` | 19 | Duplicate address in owner list |
-| `ArithmeticError` | 20 | Integer overflow |
-| `InvalidDuration` | 21 | Deadline more than 90 days in the future |
+The table below maps every `ContractError` discriminant to its cause and the recommended remediation. All codes are `u32` values encoded as `ScVal::Error` in XDR responses.
+
+| Code | Variant Name | Cause / Description | Recommended Action |
+|------|--------------|--------------------|--------------------|
+| 1 | `AlreadyInitialized` | `initialize` was called on a contract instance that has already been set up. The `INIT` storage flag is already `true`. | Deploy a fresh contract instance; do not call `initialize` twice on the same address. |
+| 2 | `NotInitialized` | A function that requires contract state (threshold, owners) was invoked before `initialize` completed successfully. | Call `initialize` first and confirm the transaction is finalized on-chain before calling any other function. |
+| 3 | `Unauthorized` | The caller's address is not present in the current owner list, or the guardian address did not match when calling `freeze`. | Ensure the signing address is a registered owner. For `freeze`, ensure the address matches the stored guardian. |
+| 4 | `InvalidThreshold` | The proposed threshold is either `0` or exceeds the current owner count (`threshold > owners.len()`). Thrown by `initialize` and `create_change_threshold_proposal`. | Supply a threshold in the range `[1, owners.len()]`. |
+| 5 | `InvalidOwners` | The owner list passed to `initialize` is empty, or `create_add_owner_proposal` was called when the owner count is already at the maximum of **20** (`MAX_OWNERS = 20`). | Provide 1–20 unique owner addresses. If the cap is reached, remove an owner before adding another. |
+| 6 | `ProposalNotFound` | No proposal record exists in persistent storage for the given `proposal_id`. | Verify the ID with `get_total_proposals` and confirm the proposal was created on the correct network/contract. |
+| 7 | `ProposalNotActive` | The proposal's derived status is `Executed`, `Expired`, or `Revoked` — any terminal state that blocks further `approve`, `revoke`, or `execute` calls. | Check the proposal status via `get_proposal` before acting. Expired proposals can only be swept via `cancel_expired`. |
+| 8 | `AlreadyApproved` | The calling owner has already cast an approval for this proposal (the approval flag in persistent storage is `true`). | Use `revoke` first to withdraw the prior approval, then re-approve if needed. |
+| 9 | `NotApproved` | `revoke` was called by an owner who has not yet approved the proposal (approval flag is `false` or absent). | Only call `revoke` after successfully calling `approve` for the same proposal. |
+| 10 | `ThresholdNotMet` | `execute` was called on a proposal whose approval count is still below the required threshold. Also raised by `set_guardian`, `unfreeze`, and `upgrade` when the `approvers` list contains fewer entries than the current threshold. | Gather the required number of owner approvals before executing. Check the current threshold via `get_threshold`. |
+| 11 | `ProposalExpired` | The ledger timestamp has surpassed the proposal's `deadline`. Raised by `execute` when it detects expiry; the proposal status is persisted as `Expired` and the active-proposal counter is decremented. | Create a new proposal with a fresh deadline. Use `cancel_expired` to sweep stale IDs and free the active-proposal slot. |
+| 12 | `InvalidAmount` | The `amount` field in `create_proposal` is less than **1** stroop (`MIN_AMOUNT = 1`). Negative and zero values are both rejected. | Pass a positive integer ≥ 1 in the token's smallest unit. For XLM this is stroops (1 XLM = 10,000,000 stroops). |
+| 13 | `InvalidDeadline` | The `deadline` timestamp is ≤ the current ledger timestamp at the time the proposal creation transaction is processed. | Set a deadline strictly in the future. Account for block-time variance by adding a buffer of at least a few minutes. |
+| 14 | `InvalidToken` | The address passed as `token` does not implement the Soroban token interface — specifically, at least one of `decimals()`, `symbol()`, or `name()` failed when probed. | Use a verified SEP-41 token address. On Testnet, use the canonical XLM, USDC, or EURC addresses listed in the frontend constants. |
+| 15 | `TransferFailed` | The on-chain `token.transfer(contract_address, recipient, amount)` call failed, typically because the contract does not hold sufficient token balance. | Fund the contract with the required token balance before executing the proposal, then retry `execute`. |
+| 16 | `EmptyDescription` | The `description` field is an empty string (length = 0). Checked in all four proposal-creation functions. | Provide a non-empty, human-readable description of the proposal's intent. |
+| 17 | `DescriptionTooLong` | The `description` field exceeds **300 characters** (`MAX_DESCRIPTION_LEN = 300`). Checked in all four proposal-creation functions. | Trim the description to 300 characters or fewer before submitting. |
+| 18 | `TooManyActiveProposals` | The number of proposals currently in `Pending` or `Ready` status has reached the cap of **50** (`MAX_ACTIVE_PROPOSALS = 50`). New proposals cannot be created until existing ones are executed or expired. | Execute or sweep at least one active proposal using `execute` or `cancel_expired`, then retry creation. |
+| 19 | `DuplicateOwner` | Two or more identical addresses appear in the owner list during `initialize`, or an address being added via `create_add_owner_proposal` already exists in the current owner list. Also checked in `set_guardian`, `unfreeze`, and `upgrade` for duplicate approver addresses. | Deduplicate all address lists before submitting. |
+| 20 | `ArithmeticError` | An integer overflow occurred — for example, the internal proposal ID counter wrapped when incrementing past `u64::MAX`, or an `approvals` counter underflowed during `checked_sub`. This is a safety guard that should never trigger in normal operation. | If encountered, contact the contract maintainers; this indicates an edge case at extreme scale. |
+| 21 | `InvalidDuration` | The gap between the current ledger timestamp and the `deadline` exceeds **7,776,000 seconds** (90 days, `MAX_PROPOSAL_DURATION`). Checked in all four proposal-creation functions. | Set a deadline no more than 90 days in the future from the current time. |
+| 22 | `InvalidRecipient` | The `to` address in `create_proposal` is the contract's own address (`env.current_contract_address()`). Self-transfers are explicitly rejected to prevent accidental fund loops. | Supply an external recipient address. The contract cannot transfer tokens to itself. |
+| 23 | `TimeLockActive` | `execute` was called before the time-lock delay has elapsed since the proposal first reached `Ready` status (`now < ready_at + time_lock_delay`). Only raised when a non-zero `time_lock_delay` was set during `initialize`. | Wait until `ready_at + time_lock_delay` has passed. Query `get_time_lock_delay` to determine the required wait period. |
+| 24 | `WouldBreakThreshold` | `create_remove_owner_proposal` was rejected because executing the removal would leave fewer owners than the current threshold (`owners.len() <= threshold`). | Lower the threshold first via `create_change_threshold_proposal`, then remove the owner, or ensure the owner count exceeds the threshold before attempting removal. |
+| 25 | `OwnerNotFound` | The address supplied to `create_remove_owner_proposal` as `owner_to_remove` is not present in the current owner list. | Verify the address is a registered owner with `is_owner` or `get_owners` before submitting a removal proposal. |
+| 26 | `ContractFrozen` | The contract's frozen flag is `true`. `create_proposal`, `create_add_owner_proposal`, `create_remove_owner_proposal`, `create_change_threshold_proposal`, and `execute` are all blocked while frozen. | The guardian must call `freeze` (already done if this error appears). Only `unfreeze` (requiring threshold co-signers) can restore normal operation. |
+| 27 | `NoGuardian` | `freeze` was called but no guardian address has been stored in the contract (the `GUARD` storage key is absent). | Call `set_guardian` with threshold-many owner approvers to register a guardian address before attempting to freeze. |
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Link,
   Route,
@@ -38,6 +38,11 @@ export default function App() {
   const [txError, setTxError] = useState<string | null>(null);
   const [txPending, setTxPending] = useState(false);
   const [isStale, setIsStale] = useState(false);
+  const [theme, setTheme] = useState<"dark" | "light">(
+    () => (localStorage.getItem("theme") as "dark" | "light" | null) ?? "dark",
+  );
+  // Ref to return focus to the "+ New" trigger after modal closes (Task 4)
+  const newProposalButtonRef = useRef<HTMLButtonElement>(null);
 
   const wallet = useWallet();
   const navigate = useNavigate();
@@ -61,6 +66,24 @@ export default function App() {
   // If the wallet is disconnected (e.g. externally, from the Freighter popup)
   // while a transaction is in flight, the pending request can never resolve.
   // Clear the pending state and surface an error instead of a stuck banner.
+  // Sync dark/light class on <html> and persist to localStorage
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  // Return focus to the New Proposal trigger when modal closes
+  useEffect(() => {
+    if (!showCreate) {
+      newProposalButtonRef.current?.focus();
+    }
+  }, [showCreate]);
+
   useEffect(() => {
     if (!wallet.address && txPending) {
       setTxPending(false);
@@ -172,10 +195,14 @@ export default function App() {
     return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
   }
 
+  function toggleTheme() {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+  }
+
   return (
-    <div className="min-h-screen bg-zinc-950 text-white">
-      <header className="border-b border-zinc-800 px-6 py-4">
-        <div className="mx-auto flex max-w-4xl items-center justify-between">
+    <div className="min-h-screen bg-white dark:bg-zinc-950 text-zinc-900 dark:text-white">
+      <header className="border-b border-zinc-800 dark:border-zinc-800 border-zinc-200 px-4 sm:px-6 py-4">
+        <div className="mx-auto flex max-w-4xl items-center justify-between gap-2">
           <Link
             to="/"
             className="flex items-center gap-3 transition-opacity hover:opacity-80"
@@ -204,6 +231,49 @@ export default function App() {
                 {label}
               </Link>
             ))}
+
+            {/* Dark / Light mode toggle */}
+            <button
+              type="button"
+              id="theme-toggle"
+              onClick={toggleTheme}
+              aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+              title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+              className="ml-1 rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-200 focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:hover:bg-zinc-800"
+            >
+              {theme === "dark" ? (
+                /* Sun icon — shown in dark mode to switch to light */
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.75}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-4 w-4"
+                  aria-hidden="true"
+                >
+                  <circle cx="12" cy="12" r="4" />
+                  <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+                </svg>
+              ) : (
+                /* Moon icon — shown in light mode to switch to dark */
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.75}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-4 w-4"
+                  aria-hidden="true"
+                >
+                  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+                </svg>
+              )}
+            </button>
           </nav>
 
           {!wallet.installed ? (
@@ -236,7 +306,7 @@ export default function App() {
         </div>
       </header>
 
-      <main className="mx-auto max-w-4xl px-6 py-8">
+      <main className="mx-auto max-w-4xl px-4 sm:px-6 py-8">
         {isStale && !loading && (
           <div className="mb-6 rounded-xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-400 font-medium">
             Data may be out of date — last updated over 60 seconds ago.
@@ -369,6 +439,7 @@ export default function App() {
           walletAddress={wallet.address}
           onClose={() => setShowCreate(false)}
           onSubmitted={refresh}
+          triggerRef={newProposalButtonRef}
         />
       )}
     </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,11 +77,13 @@ export default function App() {
     localStorage.setItem("theme", theme);
   }, [theme]);
 
-  // Return focus to the New Proposal trigger when modal closes
+  // Return focus to the New Proposal trigger when modal transitions from open → closed
+  const wasShowCreateRef = useRef(false);
   useEffect(() => {
-    if (!showCreate) {
+    if (!showCreate && wasShowCreateRef.current) {
       newProposalButtonRef.current?.focus();
     }
+    wasShowCreateRef.current = showCreate;
   }, [showCreate]);
 
   useEffect(() => {
@@ -403,6 +405,7 @@ export default function App() {
                   onExecute={handleExecute}
                   onRevoke={handleRevoke}
                   onCreateProposal={() => setShowCreate(true)}
+                  createProposalButtonRef={newProposalButtonRef}
                   loading={loading}
                   error={error}
                 />

--- a/frontend/src/components/CreateProposalModal.tsx
+++ b/frontend/src/components/CreateProposalModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, type RefObject } from "react";
 import { createProposal, estimateCreateProposalFee } from "../lib/submit";
 import { displayToStroops } from "../lib/soroban";
 import { StrKey } from "@stellar/stellar-sdk";
@@ -13,6 +13,8 @@ type Props = {
   walletAddress: string | null;
   onClose: () => void;
   onSubmitted: () => void;
+  /** Ref to the button that triggered this modal — focus is returned to it on close. */
+  triggerRef?: RefObject<HTMLButtonElement | null>;
 };
 
 function truncateAddress(address: string | null) {
@@ -20,7 +22,7 @@ function truncateAddress(address: string | null) {
   return `${address.slice(0, 6)}…${address.slice(-4)}`;
 }
 
-export function CreateProposalModal({ walletAddress, onClose, onSubmitted }: Props) {
+export function CreateProposalModal({ walletAddress, onClose, onSubmitted, triggerRef }: Props) {
   const defaultDeadline = () => {
     const d = new Date();
     d.setDate(d.getDate() + 7);
@@ -41,26 +43,73 @@ export function CreateProposalModal({ walletAddress, onClose, onSubmitted }: Pro
   const [feeError, setFeeError] = useState(false);
 
   const recipientInputRef = useRef<HTMLInputElement>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
 
+  // Initial focus: move to the recipient input on mount.
+  // On unmount, restore focus to the triggering element (or whatever was active before).
   useEffect(() => {
     const previousActiveElement = document.activeElement as HTMLElement | null;
     if (recipientInputRef.current) {
       recipientInputRef.current.focus();
     }
 
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", handleKeyDown);
-
     return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-      if (previousActiveElement && typeof previousActiveElement.focus === "function") {
+      // Prefer the explicit trigger ref; fall back to whatever had focus before mount.
+      if (triggerRef?.current && typeof triggerRef.current.focus === "function") {
+        triggerRef.current.focus();
+      } else if (previousActiveElement && typeof previousActiveElement.focus === "function") {
         previousActiveElement.focus();
       }
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Focus trap: confine Tab / Shift+Tab within the modal; Escape closes it.
+  useEffect(() => {
+    const modal = modalRef.current;
+    if (!modal) return;
+
+    const FOCUSABLE_SELECTORS =
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (e.key !== "Tab") return;
+
+      const focusable = Array.from(
+        modal.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS),
+      ).filter((el) => !el.closest('[aria-hidden="true"]'));
+
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        // Shift+Tab: wrap backward from first → last
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        // Tab: wrap forward from last → first
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    modal.addEventListener("keydown", handleKeyDown);
+    return () => modal.removeEventListener("keydown", handleKeyDown);
   }, [onClose]);
 
   const canCalculateFee = Boolean(
@@ -170,16 +219,18 @@ export function CreateProposalModal({ walletAddress, onClose, onSubmitted }: Pro
 
   return (
     <div
-      onKeyDown={(e) => {
-        if (e.key === "Escape") {
-          onClose();
-        }
-      }}
       className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+      aria-hidden="true"
     >
-      <div className="bg-zinc-900 border border-zinc-700 rounded-2xl p-4 sm:p-6 w-full max-w-md">
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-title"
+        className="bg-zinc-900 border border-zinc-700 rounded-2xl p-4 sm:p-6 w-full max-w-md"
+      >
         <div className="flex items-center justify-between mb-6">
-          <h2 className="text-white font-semibold text-lg">New Proposal</h2>
+          <h2 id="modal-title" className="text-white font-semibold text-lg">New Proposal</h2>
           <button
             type="button"
             onClick={onClose}

--- a/frontend/src/components/CreateProposalModal.tsx
+++ b/frontend/src/components/CreateProposalModal.tsx
@@ -177,7 +177,7 @@ export function CreateProposalModal({ walletAddress, onClose, onSubmitted }: Pro
       }}
       className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4"
     >
-      <div className="bg-zinc-900 border border-zinc-700 rounded-2xl p-6 w-full max-w-md">
+      <div className="bg-zinc-900 border border-zinc-700 rounded-2xl p-4 sm:p-6 w-full max-w-md">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-white font-semibold text-lg">New Proposal</h2>
           <button

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -67,8 +67,8 @@ export function ProposalCard({
 
   return (
     <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4 hover:border-zinc-700 transition-colors">
-      <div className="flex items-start justify-between mb-4">
-        <div>
+      <div className="flex items-start justify-between mb-4 gap-2">
+        <div className="min-w-0 flex-1">
           <p className="text-xs text-zinc-500 font-mono mb-1">
             Proposal #{proposal.id}
           </p>
@@ -76,7 +76,10 @@ export function ProposalCard({
             Send {proposal.amount} {proposal.token}
           </p>
           <p className="text-zinc-500 text-sm font-mono mt-0.5">
-            → {proposal.to}
+            →{" "}
+            <span className="inline-block max-w-[180px] truncate align-bottom">
+              {proposal.to}
+            </span>
           </p>
           {/* The proposer's address */}
           <div className="flex items-center gap-2 mt-0.5">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 
+/* Enable class-based dark mode (Tailwind v4 equivalent of darkMode: 'class') */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   --animate-fade-in-up: fade-in-up 1s ease-out forwards;
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 import type { DashboardStat, Owner, Proposal } from "../types/accord";
 import { ProposalCard } from "../components/ProposalCard";
 import { StatCard } from "../components/StatCard";
@@ -13,6 +13,8 @@ type DashboardPageProps = {
   onExecute: (id: number) => void;
   onRevoke: (id: number) => void;
   onCreateProposal: () => void;
+  /** Ref forwarded from App.tsx to enable focus-return after modal close */
+  createProposalButtonRef?: RefObject<HTMLButtonElement | null>;
   loading: boolean;
   error: string | null;
 };
@@ -26,6 +28,7 @@ export function DashboardPage({
   onExecute,
   onRevoke,
   onCreateProposal,
+  createProposalButtonRef,
   loading,
   error,
 }: DashboardPageProps) {
@@ -101,6 +104,7 @@ export function DashboardPage({
             Expiring first
           </label>
           <button
+            ref={createProposalButtonRef}
             type="button"
             onClick={onCreateProposal}
             className="text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-300 px-3 py-1.5 rounded-lg transition-colors"

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -143,11 +143,11 @@ export function DashboardPage({
               key={owner.address}
               className="flex items-center justify-between px-4 py-3"
             >
-              <div className="flex items-center gap-3">
-                <div className="w-7 h-7 rounded-full bg-zinc-700 flex items-center justify-center text-xs text-zinc-400">
+              <div className="flex items-center gap-3 min-w-0">
+                <div className="w-7 h-7 shrink-0 rounded-full bg-zinc-700 flex items-center justify-center text-xs text-zinc-400">
                   {owner.label[0]}
                 </div>
-                <span className="font-mono text-sm text-zinc-300">
+                <span className="font-mono text-sm text-zinc-300 truncate max-w-[180px] sm:max-w-xs">
                   {owner.address}
                 </span>
               </div>


### PR DESCRIPTION
Closes #127 
Closes #132 
Closes #129 
Closes #128

Dark/Light Mode Toggle ✅
index.css: Added @custom-variant dark (&:where(.dark, .dark *)) — the Tailwind v4 equivalent of darkMode: 'class' (no tailwind.config.js exists in this v4 project)
App.tsx: Added theme state seeded from localStorage (default 'dark'), a useEffect to toggle .dark on <html> and persist, a sun/moon <button> toggle in the nav, and swapped root classes to bg-white dark:bg-zinc-950 text-zinc-900 dark:text-white

ContractError Reference Table ✅
CONTRACT_API.md: Replaced the old 3-column stub with a comprehensive 4-column ## Error Reference table covering all 27 variants (codes 1–27, including InvalidRecipient, TimeLockActive, WouldBreakThreshold, OwnerNotFound, ContractFrozen, NoGuardian beyond the task's count of 21). Each row states exact numerical limits sourced directly from lib.rs constants.

Mobile Responsive Layout (375px) ✅
App.tsx: px-6 → px-4 sm:px-6 on header and main (done in Task 1)
ProposalCard.tsx: Recipient address wrapped in <span class="inline-block max-w-[180px] truncate align-bottom"> preserving StatusBadge position
DashboardPage.tsx: Owner address span gets truncate max-w-[180px] sm:max-w-xs; avatar div gets shrink-0
CreateProposalModal.tsx: Inner card padding p-6 → p-4 sm:p-6

Modal Accessibility Focus Trap ✅
CreateProposalModal.tsx: Added role="dialog", aria-modal="true", aria-labelledby="modal-title" on the dialog card; id="modal-title" on the heading; a modalRef scoping focusable queries; and a full Tab/Shift+Tab/Escape keyboard focus trap useEffect; the triggerRef prop restores focus to the opener on unmount
App.tsx: newProposalButtonRef ref tracked across the showCreate open→close transition, returned to the "+ New" trigger button via wasShowCreateRef guard; ref forwarded through DashboardPage and attached to the button