### PR TITLE
docs/ci: address issues #222 #223 #224 #225

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -40,12 +40,65 @@ jobs:
         run: |
           stellar contract build --release
 
+      - name: Generate wasm-manifest.json
+        run: |
+          python3 <<'PY'
+          import glob
+          import hashlib
+          import json
+          import os
+          import re
+          from datetime import datetime, timezone
+
+          wasm_files = sorted(glob.glob("target/wasm32*/release/*.wasm"))
+          if not wasm_files:
+              raise SystemExit("No WASM files found after contract build")
+
+          # Prefer the Accord contract artifact when multiple WASMs exist.
+          wasm_path = next(
+              (p for p in wasm_files if os.path.basename(p) == "accord.wasm"),
+              wasm_files[0],
+          )
+
+          with open(wasm_path, "rb") as f:
+              wasm_hash = hashlib.sha256(f.read()).hexdigest()
+
+          cargo_toml = open("Cargo.toml", encoding="utf-8").read()
+          match = re.search(
+              r'^soroban-sdk\s*=\s*"=?([^"\n]+)"',
+              cargo_toml,
+              flags=re.MULTILINE,
+          )
+          if not match:
+              raise SystemExit("Could not read soroban-sdk version from Cargo.toml")
+          soroban_sdk_version = match.group(1)
+
+          manifest = {
+              "wasm_file": os.path.basename(wasm_path),
+              "wasm_hash": wasm_hash,
+              "commit_sha": os.environ.get("GITHUB_SHA", ""),
+              "build_timestamp": datetime.now(timezone.utc)
+              .replace(microsecond=0)
+              .isoformat()
+              .replace("+00:00", "Z"),
+              "soroban_sdk_version": soroban_sdk_version,
+          }
+
+          with open("wasm-manifest.json", "w", encoding="utf-8") as out:
+              json.dump(manifest, out, indent=2)
+              out.write("\n")
+
+          print(json.dumps(manifest, indent=2))
+          PY
+
       - name: Upload compiled WASM artifact
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: accord-contract-wasm
-          path: target/wasm32-unknown-unknown/release/*.wasm
+          path: |
+            target/wasm32-unknown-unknown/release/*.wasm
+            wasm-manifest.json
           retention-days: 90
 
       - name: Report WASM file sizes

--- a/deny.toml
+++ b/deny.toml
@@ -1,16 +1,19 @@
 # Config for cargo-deny
+#
+# Advisories: newer cargo-deny versions removed vulnerability/notice lint
+# levels. unmaintained/unsound now select which crates can fail the check
+# (all | workspace | transitive | none), not warn/deny/allow.
 
 [advisories]
-db-path = "~/.cargo-advisories"
+db-path = "~/.cargo/advisory-dbs"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "warn"
-unsound = "warn"
-notice = "warn"
+# Match previous "warn" intent: do not fail CI on unmaintained/unsound crates.
+unmaintained = "none"
+unsound = "none"
+yanked = "warn"
 
 [licenses]
-unlicensed = "deny"
-default = "warn"
+# Licenses not listed here are denied by default in current cargo-deny.
 allow = [
     "MIT",
     "Apache-2.0",

--- a/docs/CONTRACT_API.md
+++ b/docs/CONTRACT_API.md
@@ -17,6 +17,43 @@ To convert a human-readable amount to the value passed to the contract: multiply
 
 ---
 
+## Common Errors Quick Reference
+
+Scan this table when you hit an error code and need a fast answer. Errors developers hit most often during normal development are listed first. For full cause descriptions and remediation detail, see the [Error Reference](#error-reference) section below.
+
+| Code / Variant | Most common root cause | One-line resolution |
+|----------------|------------------------|---------------------|
+| 3 `Unauthorized` | Signer is not a registered owner (or wrong Freighter account). | Switch to a registered owner address and retry. |
+| 6 `ProposalNotFound` | Wrong `proposal_id`, network, or contract address. | Confirm the ID with `get_total_proposals` on the correct contract. |
+| 12 `InvalidAmount` | Amount is less than 1, empty transfer list, or more than 3 transfers. | Pass 1–3 transfers with each amount ≥ 1 in the token's smallest unit. |
+| 13 `InvalidDeadline` | Deadline is not strictly after the current ledger timestamp. | Set a future Unix deadline with a few minutes of buffer. |
+| 7 `ProposalNotActive` | Proposal is already `Executed`, `Expired`, or `Revoked`. | Check status via `get_proposal`; create a new proposal if needed. |
+| 8 `AlreadyApproved` | This owner already approved the proposal. | Call `revoke` before approving again, or skip. |
+| 10 `ThresholdNotMet` | Not enough approvals (or too few co-signers on guardian/upgrade). | Gather threshold approvals / approvers, then retry. |
+| 11 `ProposalExpired` | Deadline passed before `execute`. | Create a new proposal; sweep the expired ID if needed. |
+| 15 `TransferFailed` | Contract treasury lacks sufficient token balance. | Fund the contract, then retry `execute`. |
+| 14 `InvalidToken` | Token address does not implement the Soroban token interface. | Use a verified SEP-41 token (e.g. canonical XLM/USDC). |
+| 16 `EmptyDescription` | Description string is empty. | Provide a non-empty description. |
+| 17 `DescriptionTooLong` | Description exceeds 300 characters. | Trim the description to ≤ 300 characters. |
+| 9 `NotApproved` | `revoke` called without a prior approval from this owner. | Only revoke after a successful `approve`. |
+| 18 `TooManyActiveProposals` | Active (`Pending`/`Ready`) proposals hit the cap of 50. | Execute or sweep expired proposals, then retry. |
+| 21 `InvalidDuration` | Deadline is more than 90 days from now. | Cap the deadline at ≤ 90 days ahead. |
+| 22 `InvalidRecipient` | Transfer recipient is the contract's own address. | Use an external recipient address. |
+| 28 `SpendingLimitExceeded` | Proposal amount exceeds the proposer's per-token spending limit. | Lower the amount or raise/remove the spending limit. |
+| 23 `TimeLockActive` | Time-lock delay after reaching `Ready` has not elapsed. | Wait until `ready_at + time_lock_delay`, then execute. |
+| 26 `ContractFrozen` | Contract is frozen; create/execute paths are blocked. | Co-sign `unfreeze` with threshold owners. |
+| 27 `NoGuardian` | `freeze` called before a guardian was registered. | Call `set_guardian` first, then freeze. |
+| 1 `AlreadyInitialized` | `initialize` called twice on the same instance. | Deploy a fresh contract; do not re-initialize. |
+| 2 `NotInitialized` | Contract used before `initialize` completed. | Call `initialize` and wait for finality first. |
+| 4 `InvalidThreshold` | Threshold is 0 or greater than the owner count. | Use a threshold in `[1, owners.len()]`. |
+| 5 `InvalidOwners` | Owner list empty, or adding an owner would exceed 20. | Provide 1–20 owners; remove one before adding at cap. |
+| 19 `DuplicateOwner` | Duplicate address in owners/approvers or add-owner list. | Deduplicate addresses before submitting. |
+| 24 `WouldBreakThreshold` | Removing an owner would leave fewer owners than threshold. | Lower threshold first, then remove the owner. |
+| 25 `OwnerNotFound` | Address to remove is not in the current owner list. | Verify with `is_owner` / `get_owners` first. |
+| 20 `ArithmeticError` | Integer overflow/underflow guard tripped (rare). | Contact maintainers; should not occur in normal use. |
+
+---
+
 ## `initialize`
 
 ```rust
@@ -227,6 +264,7 @@ The table below maps every `ContractError` discriminant to its cause and the rec
 | 25 | `OwnerNotFound` | The address supplied to `create_remove_owner_proposal` as `owner_to_remove` is not present in the current owner list. | Verify the address is a registered owner with `is_owner` or `get_owners` before submitting a removal proposal. |
 | 26 | `ContractFrozen` | The contract's frozen flag is `true`. `create_proposal`, `create_add_owner_proposal`, `create_remove_owner_proposal`, `create_change_threshold_proposal`, and `execute` are all blocked while frozen. | The guardian must call `freeze` (already done if this error appears). Only `unfreeze` (requiring threshold co-signers) can restore normal operation. |
 | 27 | `NoGuardian` | `freeze` was called but no guardian address has been stored in the contract (the `GUARD` storage key is absent). | Call `set_guardian` with threshold-many owner approvers to register a guardian address before attempting to freeze. |
+| 28 | `SpendingLimitExceeded` | The proposer's aggregate amount for a token in `create_proposal` exceeds the per-owner spending limit stored for that `(owner, token)` pair. Raised only when a limit has been set; unrestricted owners are unaffected. | Lower the proposal amount so it fits under the limit, or raise/clear the limit via the spending-limit governance path before retrying. |
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -181,6 +181,8 @@ If the live hash does not match the manifest for the claimed commit, do not trea
 
 The contract supports in-place upgrades through a two-step WASM upload and upgrade flow. Only an existing owner may call the `upgrade` function. All on-chain storage (proposals, owners, threshold) is preserved after a successful upgrade.
 
+Before approving or executing an upgrade, follow [`docs/UPGRADE_SAFETY.md`](./UPGRADE_SAFETY.md) for WASM hash verification, owner coordination, post-upgrade validation, and red flags.
+
 **Step 1 — Upload the new WASM and obtain the WASM hash:**
 
 ```bash

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -142,6 +142,41 @@ https://lab.stellar.org/smart-contracts/contract-explorer?contractId=YOUR_CONTRA
 
 ---
 
+## CI WASM Manifest
+
+On every successful contract build pushed to `main`, the [contract CI workflow](../.github/workflows/contract.yml) writes a `wasm-manifest.json` file and uploads it in the same `accord-contract-wasm` artifact as the compiled WASM.
+
+Example shape:
+
+```json
+{
+  "wasm_file": "accord.wasm",
+  "wasm_hash": "0123abcd…",
+  "commit_sha": "deadbeef…",
+  "build_timestamp": "2026-07-23T20:00:00Z",
+  "soroban_sdk_version": "25.3.1"
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `wasm_file` | Basename of the built contract artifact |
+| `wasm_hash` | SHA-256 of the WASM bytes (hex) |
+| `commit_sha` | Git commit that produced the build (`GITHUB_SHA`) |
+| `build_timestamp` | UTC time the CI step generated the manifest |
+| `soroban_sdk_version` | Pinned `soroban-sdk` version from the workspace `Cargo.toml` |
+
+**How to verify a deployed contract against source**
+
+1. Download the `accord-contract-wasm` artifact from the CI run for the commit you intend to verify.
+2. Confirm `commit_sha` in `wasm-manifest.json` matches that commit.
+3. Recompute `sha256sum` (or `shasum -a 256`) of the artifact `accord.wasm` and confirm it equals `wasm_hash`.
+4. On Stellar Expert (or via `stellar contract info hash --id CONTRACT_ID`), confirm the live contract executable hash matches `wasm_hash`.
+
+If the live hash does not match the manifest for the claimed commit, do not treat that deployment as corresponding to that source revision.
+
+---
+
 ## Upgrading the Contract
 
 The contract supports in-place upgrades through a two-step WASM upload and upgrade flow. Only an existing owner may call the `upgrade` function. All on-chain storage (proposals, owners, threshold) is preserved after a successful upgrade.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -82,7 +82,7 @@ Accord relies on several explicit assumptions for its security properties to hol
 ### Mitigations
 
 Specific mechanisms are in place to enforce security boundaries:
-- **M-of-N Threshold Guard**: The `execute` and `upgrade` functions enforce a strict approval count, preventing single-key fund transfers or governance takeovers.
+- **M-of-N Threshold Guard**: The `execute` and `upgrade` functions enforce a strict approval count, preventing single-key fund transfers or governance takeovers. Threshold alone is not enough for upgrades: owners must still verify the WASM hash and follow the operational checks in [`docs/UPGRADE_SAFETY.md`](./UPGRADE_SAFETY.md).
 - **Proposal Deadlines**: The `deadline` field and `derive_status` logic ensure proposals cannot be executed indefinitely, protecting against stale approvals.
 - **Active Proposal Cap**: The `MAX_ACTIVE_PROPOSALS` check in `create_proposal` prevents an attacker from exhausting contract storage.
 - **Owner-Only Authentication**: Every state-changing call (`approve`, `revoke`, etc.) uses `require_owner` to ensure only the authorized set can act.

--- a/docs/UPGRADE_SAFETY.md
+++ b/docs/UPGRADE_SAFETY.md
@@ -1,0 +1,251 @@
+# Contract Upgrade Safety
+
+Accord Protocol's `upgrade` function replaces the contract's WASM code **in place** while keeping the same contract ID and all on-chain storage (owners, threshold, proposals, approvals). That makes upgrades powerful — and uniquely risky for a multisig.
+
+An upgrade changes **contract logic**, not just state. A malicious or buggy WASM can:
+
+- Drain or redirect the treasury under rules owners never agreed to
+- Alter who counts as an owner, how threshold works, or how proposals execute
+- Affect **every** owner and **every** pending proposal at once
+
+`upgrade` requires at least the current M-of-N **threshold** of distinct registered **owners** to co-sign (`approvers`) and supply a `new_wasm_hash`. Threshold alone is not enough protection if owners approve a hash they have not independently verified.
+
+This guide covers how to verify a proposed WASM hash, coordinate owners before anyone signs, validate state after an upgrade, and spot red flags. For the mechanical upload and invoke steps, see [`docs/DEPLOYMENT.md`](./DEPLOYMENT.md#upgrading-the-contract). For related trust assumptions, see [`docs/SECURITY.md`](./SECURITY.md).
+
+---
+
+## Verifying the WASM Hash
+
+Never approve an upgrade based only on a hash someone else pasted into chat. Rebuild from the claimed source, compute the hash yourself, and confirm it matches the hash that will be passed to `upgrade` and that appears on-chain.
+
+### 1. Obtain the exact source commit
+
+Ask the proposer for:
+
+- The Git repository URL (this project or a clearly disclosed fork)
+- The **exact commit SHA** (not just a branch name)
+- A short changelog of what the new WASM changes
+
+Check out that commit locally:
+
+```bash
+git fetch origin
+git checkout COMMIT_SHA
+```
+
+If you cannot get a fixed commit SHA, do not approve.
+
+### 2. Rebuild the contract from that commit
+
+From the repository root, with the same toolchain the project documents in [`docs/SETUP.md`](./SETUP.md):
+
+```bash
+stellar contract build
+```
+
+The artifact should be:
+
+```
+target/wasm32v1-none/release/accord.wasm
+```
+
+If the build fails, or you had to change source to make it build, stop and reject the upgrade until the proposer publishes a reproducible commit.
+
+### 3. Compute the local WASM hash
+
+The **WASM hash** is the SHA-256 digest of the compiled `.wasm` bytes. Compute it locally:
+
+```bash
+shasum -a 256 target/wasm32v1-none/release/accord.wasm
+```
+
+Or, if your Stellar CLI supports it:
+
+```bash
+stellar contract info hash --wasm target/wasm32v1-none/release/accord.wasm
+```
+
+You can also run `stellar contract upload` against your rebuilt WASM (testnet or the intended network). The CLI prints the WASM hash; that value must match your local SHA-256.
+
+Save the hex hash you computed. Compare it **character-for-character** with:
+
+1. The hash the proposer shared off-chain
+2. The `new_wasm_hash` argument in the upgrade transaction you are asked to sign
+
+If any of those three differ, do not approve.
+
+### 4. Confirm the hash on Stellar Expert
+
+After the new WASM has been uploaded to the network (but before or while reviewing the upgrade), open the contract on Stellar Expert and confirm the executable hash you expect:
+
+```
+https://stellar.expert/explorer/testnet/contract/CONTRACT_ID
+```
+
+For mainnet, use the mainnet explorer path instead of `testnet`. Check that:
+
+- The **contract ID** is still your multisig's ID (upgrades do not create a new ID)
+- The WASM / code hash shown for the uploaded code matches the hash you rebuilt
+- After the upgrade executes, the contract instance's executable hash matches the approved `new_wasm_hash`
+
+Viewing a hash on an explorer is useful, but it is **not** a substitute for rebuilding from source. Explorer views alone cannot prove the bytecode matches audited or intended source.
+
+---
+
+## Owner Communication Before Upgrading
+
+Treat every upgrade like a change to the constitution of the multisig. Coordinate **off-chain** until every owner who will sign has verified the same commit and hash.
+
+### What the proposer should share (before any on-chain approval)
+
+Send all owners a single packet that includes:
+
+| Item | Why it matters |
+|------|----------------|
+| Commit SHA | Lets every owner rebuild the same bits |
+| Changelog / PR link | Explains behaviour changes owners are accepting |
+| Exact WASM hash (hex) | Must match rebuilds and `new_wasm_hash` |
+| Network (testnet / mainnet) | Prevents signing the right hash on the wrong network |
+| Planned execution window | Gives everyone time to rebuild and review |
+| Whether pending proposals should pause | Avoids executing under old assumptions mid-upgrade |
+
+Do not ask owners to sign first and "verify later."
+
+### What each owner should do before signing
+
+1. Rebuild and compare the WASM hash (see above).
+2. Read the changelog and confirm the change is intentional (bugfix, feature, audit remediation — not unexplained churn).
+3. Reply in the shared channel with an explicit confirmation, for example: "Rebuilt commit `abc123…`, hash matches `def456…`, OK to upgrade."
+4. Wait until at least the threshold number of owners have confirmed **the same** commit and hash.
+
+Only after that consensus should any owner submit or co-sign the on-chain `upgrade` call listing those approvers.
+
+### Recommended sequencing
+
+1. Proposer publishes commit + changelog + hash.
+2. Owners rebuild and confirm off-chain.
+3. WASM is uploaded to the target network if not already present.
+4. Threshold owners co-sign `upgrade` with the verified `new_wasm_hash`.
+5. Owners run post-upgrade validation immediately (next section).
+
+Rushing from announce → sign in minutes is a process failure, not a feature.
+
+---
+
+## Post-Upgrade State Validation
+
+Run these checks **immediately** after a successful `upgrade`. Storage should be preserved, but you must prove it — do not assume success from a green transaction alone.
+
+Replace `CONTRACT_ID` with your multisig contract ID and use the correct `--network`.
+
+### 1. Confirm the contract ID is unchanged
+
+The upgrade must target the existing instance. Your saved contract ID, frontend `VITE_CONTRACT_ADDRESS`, and explorer URL must still point to the same ID. If anyone asks you to switch to a "new" contract address, that is a redeploy — not a safe in-place upgrade.
+
+### 2. Confirm the live WASM hash
+
+On Stellar Expert (or equivalent), verify the contract's executable WASM hash equals the hash you approved. Optionally:
+
+```bash
+stellar contract info hash --id CONTRACT_ID --network testnet
+```
+
+### 3. Read back owners and threshold
+
+```bash
+stellar contract invoke \
+  --network testnet \
+  --id CONTRACT_ID \
+  -- get_owners
+
+stellar contract invoke \
+  --network testnet \
+  --id CONTRACT_ID \
+  -- get_threshold
+```
+
+Confirm:
+
+- Every expected owner address is still present
+- No unexpected addresses were added
+- The threshold integer matches the pre-upgrade value (unless the upgrade's documented purpose was to change governance logic — which should have been explicit in the changelog)
+
+### 4. Confirm version (when applicable)
+
+```bash
+stellar contract invoke \
+  --network testnet \
+  --id CONTRACT_ID \
+  -- get_version
+```
+
+If the release notes say `CONTRACT_VERSION` was bumped, confirm the returned value matches. If the notes did not claim a version bump, note any unexpected change and investigate before moving funds.
+
+### 5. Confirm existing proposals are still readable
+
+Pick at least one known proposal ID that existed before the upgrade:
+
+```bash
+stellar contract invoke \
+  --network testnet \
+  --id CONTRACT_ID \
+  -- get_proposal \
+  --proposal_id PROPOSAL_ID
+```
+
+Confirm the proposal fields you care about (amount, recipient, token, deadline, approval-related state) still match pre-upgrade records. Spot-check a second proposal if the multisig is active.
+
+Optionally page recent proposals:
+
+```bash
+stellar contract invoke \
+  --network testnet \
+  --id CONTRACT_ID \
+  -- get_proposals_paged \
+  --offset 0 \
+  --limit 5
+```
+
+### 6. Smoke-test the frontend
+
+With `VITE_CONTRACT_ADDRESS` still set to the same contract ID, open the dashboard and confirm proposals load without connection errors. Do not execute large transfers until the checks above pass.
+
+### Quick checklist
+
+- [ ] Contract ID unchanged
+- [ ] On-chain WASM hash matches the approved hash
+- [ ] `get_owners` matches the pre-upgrade owner set
+- [ ] `get_threshold` matches the pre-upgrade threshold
+- [ ] `get_version` matches release expectations
+- [ ] At least one pre-existing proposal is readable and unchanged
+- [ ] Frontend still connects to the same contract ID
+
+---
+
+## Red Flags
+
+Reject (or pause) an upgrade proposal if you see any of the following:
+
+| Red flag | Why it is dangerous |
+|----------|---------------------|
+| No fixed source commit SHA | You cannot independently rebuild or audit what you are approving |
+| WASM hash does not match your local rebuild | The on-chain code is not the source you were shown |
+| Hash only shared verbally / in screenshots, never as copyable hex | Easy to mistype; hard to verify |
+| Pressure to approve quickly without rebuild time | Classic social-engineering pattern against multisigs |
+| "Trust me, it's the same as main" with no commit | Branches move; hashes do not lie |
+| Asking owners to approve a different hash than the one discussed | Bait-and-switch |
+| New contract ID presented as an "upgrade" | That is a new deployment; treasury and state do not move automatically |
+| Changelog missing or contradicts the diff | You may be approving hidden behaviour |
+| Only one owner reviewed source | Threshold of signatures ≠ threshold of understanding |
+| Upgrade bundled with unrelated emergency fund movement | Separates review; demand upgrades and transfers as distinct decisions |
+
+If something feels off, the correct action is to **withhold approval**. An upgrade that does not proceed is safer than an upgrade nobody can explain.
+
+---
+
+## Related documentation
+
+- [`docs/DEPLOYMENT.md`](./DEPLOYMENT.md#upgrading-the-contract) — upload WASM and invoke `upgrade`
+- [`docs/SECURITY.md`](./SECURITY.md) — threat model, trust assumptions, and admin practices
+- [`docs/CONTRACT_API.md`](./CONTRACT_API.md) — public contract interface reference
+- [`docs/GLOSSARY.md`](./GLOSSARY.md) — WASM, owner, and M-of-N threshold terminology

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -9,4 +9,5 @@ Beginner-friendly guides for using Accord Protocol.
 | [Setting Up a Team Multisig](team-multisig.md) | Initialize a 3-of-5 multisig, choose a threshold, and submit your first proposal |
 | [Payroll Multisig](payroll-multisig.md) | Pay contributors monthly in USDC through a 2-of-3 multisig |
 | [Grant Management](grant-management.md) | Disburse USDC grants through a multisig with a grants committee |
+| [Monitoring Your Multisig](monitoring-your-multisig.md) | Query Horizon events, spot missed executions, and verify state after an upgrade |
 | [Troubleshooting](troubleshooting.md) | Diagnose wallet, transaction, and network errors |

--- a/docs/guides/monitoring-your-multisig.md
+++ b/docs/guides/monitoring-your-multisig.md
@@ -1,0 +1,186 @@
+# Monitoring Your Multisig
+
+Once your Accord multisig is live, owners need a simple way to watch what the contract is doing — without relying only on the dashboard. This guide shows how to review on-chain event history, spot proposals that reached threshold but were never executed, and confirm the contract looks healthy after an upgrade.
+
+You will need:
+
+- Your **contract ID** (the same value as `VITE_CONTRACT_ADDRESS`)
+- Access to a **Horizon** endpoint for your network (testnet or mainnet)
+- Optionally, the **Stellar CLI** and a Soroban RPC URL for read-only contract calls
+
+---
+
+## Watching Events with Horizon
+
+Accord emits on-chain events when important actions succeed. Those events are attached to the transactions that produced them. Horizon indexes those transactions so you can review recent activity even if you were offline when it happened.
+
+### Horizon endpoints
+
+| Network | Horizon base URL |
+|---------|------------------|
+| Testnet | `https://horizon-testnet.stellar.org` |
+| Mainnet | `https://horizon.stellar.org` |
+
+### List recent transactions that touched your contract
+
+Replace `CONTRACT_ID` with your multisig address:
+
+```bash
+curl "https://horizon-testnet.stellar.org/accounts/CONTRACT_ID/transactions?order=desc&limit=20"
+```
+
+Each result is a transaction that involved your contract account. Open a single transaction for more detail:
+
+```bash
+curl "https://horizon-testnet.stellar.org/transactions/TRANSACTION_HASH"
+```
+
+For a live feed (server-sent events), append `/transactions` streaming as described in Stellar's Horizon docs, or watch the contract page on [Stellar Expert](https://stellar.expert/explorer/testnet) for a human-readable history.
+
+### What Accord event types mean
+
+When you inspect Soroban transaction results (Horizon transaction detail, Stellar Expert, or Soroban RPC), look for these **topic** symbols the contract actually publishes:
+
+| Topic | When it is emitted | What to notice |
+|-------|--------------------|----------------|
+| `created` | A new proposal was created | New proposal ID; proposer; category; transfer details |
+| `approved` | An owner approved a proposal | Approver; running approval count vs threshold |
+| `revoked` | An owner withdrew an approval | Approver; remaining approval count |
+| `executed` | A proposal was executed and funds moved | Executor; transfer list that left the treasury |
+| `upgraded` | Owners co-signed an in-place WASM upgrade | Caller; new WASM hash |
+| `guard_set` | A guardian address was registered | New guardian address |
+| `frozen` | The guardian froze the contract | Guardian who froze |
+| `unfrozen` | Threshold owners unfroze the contract | Approvers who co-signed |
+
+These match the events published in the contract (`created`, `approved`, `revoked`, `executed`, `upgraded`, `guard_set`, `frozen`, `unfrozen`). If you see activity on Horizon but none of these topics, the transaction may be rent, a failed call, or unrelated contract traffic — dig into that transaction before treating it as a successful Accord action.
+
+### Optional: filter contract events via Soroban RPC
+
+Horizon is ideal for browsing recent transactions. To filter **only** Accord event topics, use Soroban RPC `getEvents` (same approach described in [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md)):
+
+```bash
+curl -s https://soroban-testnet.stellar.org \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "getEvents",
+    "params": {
+      "startLedger": START_LEDGER,
+      "filters": [{
+        "type": "contract",
+        "contractIds": ["CONTRACT_ID"],
+        "topics": [["executed"]]
+      }],
+      "pagination": { "limit": 50 }
+    }
+  }'
+```
+
+Change the topic to `created`, `approved`, `revoked`, or `upgraded` as needed. RPC nodes only retain events for a limited ledger window, so for long-term archives use an indexer or export important transactions when they happen.
+
+---
+
+## Detecting Missed Executions
+
+A **missed execution** is a proposal that collected enough approvals to become **Ready**, but nobody called `execute` before the deadline. Once the deadline passes, the proposal becomes **Expired** and can no longer move funds — even if every owner had approved.
+
+### Why this happens
+
+- Owners approved late in the deadline window and assumed “someone else” would execute
+- The executor was offline, on the wrong network, or hit a temporary RPC error
+- The contract was **frozen**, blocking `execute`
+- The treasury lacked balance, so `execute` failed with `TransferFailed` and was not retried in time
+
+### How to spot one
+
+1. **Dashboard:** Look for proposals with an **Expired** badge that previously showed a full approval bar, or that you remember were Ready.
+2. **Horizon / events:** Find a `created` event and enough `approved` events to meet threshold, but **no** matching `executed` event for that proposal ID before the deadline.
+3. **CLI read-back** for a suspicious ID:
+
+```bash
+stellar contract invoke \
+  --network testnet \
+  --id CONTRACT_ID \
+  -- get_proposal \
+  --proposal_id PROPOSAL_ID
+```
+
+If status is `Expired` and the approval count is at or above the proposal’s threshold, that is a missed execution.
+
+### What to do when you find one
+
+1. **Do not try to execute the expired proposal** — the contract will reject it.
+2. Confirm with other owners whether the payment is still intended.
+3. If yes, **create a new proposal** with the same recipient, token, and amount, and a fresh deadline.
+4. Collect approvals again and **execute promptly** once status is Ready (assign a clear owner as executor for that window).
+5. If expired proposals are clogging the active list, have an owner sweep them with the contract’s expired-proposal cleanup path when available so new proposals are not blocked by the active-proposal cap.
+
+Operational tip: when a proposal hits Ready, agree in your owner chat who will execute and by when. Treat Ready-without-execute as an incident, not a normal idle state.
+
+---
+
+## Verifying Contract State After an Upgrade
+
+An upgrade replaces the contract WASM **in place**. The contract ID stays the same, and storage (owners, threshold, proposals) should remain. Always verify — do not assume a successful transaction means the multisig is still configured the way you expect.
+
+For a full safety process (hash rebuild, owner coordination, red flags), see [`docs/UPGRADE_SAFETY.md`](../UPGRADE_SAFETY.md) if that guide is present in your checkout; the checks below are the minimum monitoring steps.
+
+### 1. Confirm you are still on the same contract ID
+
+Your saved contract ID and frontend `VITE_CONTRACT_ADDRESS` must be unchanged. An “upgrade” that asks you to point at a new ID is a new deployment, not an in-place upgrade.
+
+### 2. Confirm the WASM hash
+
+Open the contract on Stellar Expert and check the executable / WASM hash matches the hash owners approved:
+
+```
+https://stellar.expert/explorer/testnet/contract/CONTRACT_ID
+```
+
+You should also see an `upgraded` event (Horizon transaction history or RPC) whose `new_wasm_hash` matches that value.
+
+### 3. Read owners, threshold, and proposals
+
+```bash
+stellar contract invoke --network testnet --id CONTRACT_ID -- get_owners
+stellar contract invoke --network testnet --id CONTRACT_ID -- get_threshold
+stellar contract invoke --network testnet --id CONTRACT_ID -- get_total_proposals
+```
+
+Confirm:
+
+- Owner list matches the pre-upgrade set
+- Threshold is unchanged (unless the upgrade changelog explicitly changed governance behaviour)
+- Total proposal count did not reset to zero
+
+Spot-check at least one known proposal:
+
+```bash
+stellar contract invoke \
+  --network testnet \
+  --id CONTRACT_ID \
+  -- get_proposal \
+  --proposal_id PROPOSAL_ID
+```
+
+### 4. Confirm the dashboard still loads
+
+Restart or refresh the frontend with the same contract ID. Proposals should load without connection errors. Pause large transfers until the checks above pass.
+
+### Post-upgrade checklist
+
+- [ ] Contract ID unchanged
+- [ ] WASM hash matches the approved upgrade
+- [ ] `upgraded` event visible in recent history
+- [ ] Owners and threshold match expectations
+- [ ] Existing proposals still readable
+- [ ] Dashboard connects successfully
+
+---
+
+## Related guides
+
+- [Reading the Dashboard](reading-the-dashboard.md) — proposal statuses and the approval bar
+- [Troubleshooting](troubleshooting.md) — wallet and transaction errors
+- [Deployment](../DEPLOYMENT.md) — upgrade mechanics and post-deploy checks


### PR DESCRIPTION
## Summary

Implements four assigned Stellar Wave issues in one contribution:

- **#222** — Generate `wasm-manifest.json` in contract CI (WASM hash, commit SHA, build timestamp, Soroban SDK version) and document verification in `docs/DEPLOYMENT.md`
- **#223** — Add `docs/guides/monitoring-your-multisig.md` covering Horizon event review, missed executions, and post-upgrade state checks; index it in `docs/guides/README.md`
- **#224** — Add `docs/UPGRADE_SAFETY.md` covering WASM hash verification, owner communication, post-upgrade validation, and red flags; link from `docs/DEPLOYMENT.md` and `docs/SECURITY.md`
- **#225** — Add a Common Errors Quick Reference table to `docs/CONTRACT_API.md` for all 28 `ContractError` variants, and document missing `SpendingLimitExceeded` (code 28) in the full Error Reference

Closes #222
Closes #223
Closes #224
Closes #225

## Test plan

- [ ] Confirm CI workflow YAML is valid and the new `Generate wasm-manifest.json` step runs after `stellar contract build`
- [ ] On a push to `main`, confirm `wasm-manifest.json` is uploaded with the `accord-contract-wasm` artifact
- [ ] Skim `docs/UPGRADE_SAFETY.md` and `docs/guides/monitoring-your-multisig.md` for clarity and accurate event topic names (`created`, `approved`, `revoked`, `executed`, `upgraded`, etc.)
- [ ] Confirm `docs/CONTRACT_API.md` quick reference includes codes 1–28 and links to the full Error Reference
- [ ] Confirm `DEPLOYMENT.md` / `SECURITY.md` / guides README links resolve