### PR TITLE
Feat  resolve issues #242 #243 #244 #245

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { useEventPolling } from "./hooks/useEventPolling";
 import { useNotifications } from "./hooks/useNotifications";
 import { useWallet } from "./hooks/useWallet";
 import { approveProposal, executeProposal, revokeProposal } from "./lib/submit";
+import { isFrozen } from "./lib/contract";
 import { DashboardPage } from "./pages/DashboardPage";
 import { HistoryPage } from "./pages/HistoryPage";
 import { NotFoundPage } from "./pages/NotFoundPage";
@@ -38,6 +39,7 @@ export default function App() {
   const [txError, setTxError] = useState<string | null>(null);
   const [txPending, setTxPending] = useState(false);
   const [isStale, setIsStale] = useState(false);
+  const [contractFrozen, setContractFrozen] = useState(false);
   const [theme, setTheme] = useState<"dark" | "light">(
     () => (localStorage.getItem("theme") as "dark" | "light" | null) ?? "dark",
   );
@@ -102,6 +104,25 @@ export default function App() {
       }
     }, 10000);
     return () => clearInterval(interval);
+  }, [lastSuccessAt]);
+
+  // Poll frozen state
+  useEffect(() => {
+    let cancelled = false;
+    async function check() {
+      try {
+        const f = await isFrozen();
+        if (!cancelled) setContractFrozen(f);
+      } catch {
+        // ignore
+      }
+    }
+    check();
+    const interval = setInterval(check, 15000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
   }, [lastSuccessAt]);
 
   const activeProposals = proposals.filter((proposal) =>
@@ -309,8 +330,17 @@ export default function App() {
       </header>
 
       <main className="mx-auto max-w-4xl px-4 sm:px-6 py-8">
+        {contractFrozen && (
+          <div className="mb-6 rounded-xl border border-red-500/30 bg-red-500/20 px-4 py-3 text-sm text-red-300 font-medium flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5 shrink-0">
+              <path fillRule="evenodd" d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003zM12 8.25a.75.75 0 01.75.75v3.75a.75.75 0 01-1.5 0V9a.75.75 0 01.75-.75zm0 8.25a.75.75 0 100-1.5.75.75 0 000 1.5z" clipRule="evenodd" />
+            </svg>
+            Contract is currently frozen. All proposal creation and execution has been paused.
+          </div>
+        )}
+
         {isStale && !loading && (
-          <div className="mb-6 rounded-xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-400 font-medium">
+          <div className="mb-6 rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-sm text-amber-400 font-medium">
             Data may be out of date — last updated over 60 seconds ago.
           </div>
         )}
@@ -430,7 +460,7 @@ export default function App() {
                 />
               }
             />
-            <Route path="settings" element={<SettingsPage stats={stats} />} />
+            <Route path="settings" element={<SettingsPage stats={stats} walletAddress={wallet.address} ownerAddresses={ownerAddresses} onProposalSubmitted={refresh} />} />
             <Route
               path="/proposals/:id"
               element={

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -422,8 +422,11 @@ export default function App() {
               element={
                 <OwnersPage
                   owners={owners}
+                  ownerAddresses={ownerAddresses}
                   threshold={threshold}
                   totalOwners={owners.length}
+                  walletAddress={wallet.address}
+                  onProposalSubmitted={refresh}
                 />
               }
             />

--- a/frontend/src/components/CreateProposalModal.test.tsx
+++ b/frontend/src/components/CreateProposalModal.test.tsx
@@ -4,12 +4,25 @@ import userEvent from "@testing-library/user-event";
 import { CreateProposalModal } from "./CreateProposalModal";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import { estimateCreateProposalFee, createProposal } from "../lib/submit";
+import { getOwners, getThreshold } from "../lib/contract";
 import { StrKey } from "@stellar/stellar-sdk";
 
 // Mock the submit logic
 vi.mock("../lib/submit", () => ({
   createProposal: vi.fn(),
+  createAddOwnerProposal: vi.fn(),
+  createRemoveOwnerProposal: vi.fn(),
+  createChangeThresholdProposal: vi.fn(),
   estimateCreateProposalFee: vi.fn(),
+}));
+
+// Mock contract reads
+vi.mock("../lib/contract", () => ({
+  getOwners: vi.fn().mockResolvedValue([
+    "GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4IQDNC",
+    "GBPLX2P3VWYKPQ7L5RI5OGXQ6T4G7QZMJ3HPQD7FZX5KJ3H2Z4YK5ABC",
+  ]),
+  getThreshold: vi.fn().mockResolvedValue(2),
 }));
 
 // Mock StrKey to avoid validation issues with dummy addresses
@@ -24,6 +37,8 @@ vi.mock("@stellar/stellar-sdk", async () => {
   };
 });
 
+type Act = (e: React.ReactElement) => void;
+
 describe("CreateProposalModal", () => {
   const defaultProps = {
     walletAddress: "GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4IQDNC",
@@ -36,7 +51,12 @@ describe("CreateProposalModal", () => {
     (StrKey.isValidEd25519PublicKey as any).mockReturnValue(true);
   });
 
-  const fillRequiredFields = () => {
+  const selectTransfer = () => {
+    fireEvent.click(screen.getByText("Transfer"));
+  };
+
+  const fillTransferFields = () => {
+    selectTransfer();
     fireEvent.change(screen.getByPlaceholderText("G..."), { target: { value: "GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4IQDNC" } });
     fireEvent.change(screen.getByPlaceholderText("0.00"), { target: { value: "10" } });
     fireEvent.change(screen.getByPlaceholderText("What is this payment for?"), { target: { value: "Test payment" } });
@@ -49,6 +69,7 @@ describe("CreateProposalModal", () => {
 
   it("Typing text should not show error if mocked valid", () => {
     render(<CreateProposalModal {...defaultProps} />);
+    selectTransfer();
     const input = screen.getByPlaceholderText("G...");
     fireEvent.change(input, { target: { value: "abc123" } });
     expect(screen.queryByText("Enter a valid Stellar address")).toBeNull();
@@ -56,18 +77,19 @@ describe("CreateProposalModal", () => {
 
   it("Calculate fee button hidden when wallet disconnected", () => {
     render(<CreateProposalModal {...defaultProps} walletAddress={null} />);
-    fillRequiredFields();
+    fillTransferFields();
     expect(screen.queryByText("Calculate fee")).toBeNull();
   });
 
   it("Button appears when all required fields are present", () => {
     render(<CreateProposalModal {...defaultProps} />);
-    fillRequiredFields();
+    fillTransferFields();
     expect(screen.getByText("Calculate fee")).toBeDefined();
   });
 
   it("shows description count, caps input at 300 characters, and marks the limit in red", async () => {
     render(<CreateProposalModal {...defaultProps} />);
+    selectTransfer();
 
     const descriptionInput = screen.getByPlaceholderText(
       "What is this payment for?"
@@ -87,7 +109,7 @@ describe("CreateProposalModal", () => {
     (estimateCreateProposalFee as any).mockResolvedValue(0.012345);
 
     render(<CreateProposalModal {...defaultProps} />);
-    fillRequiredFields();
+    fillTransferFields();
 
     const calcBtn = screen.getByText("Calculate fee");
     fireEvent.click(calcBtn);
@@ -104,7 +126,7 @@ describe("CreateProposalModal", () => {
     (createProposal as any).mockResolvedValue(undefined);
 
     render(<CreateProposalModal {...defaultProps} />);
-    fillRequiredFields();
+    fillTransferFields();
 
     const calcBtn = screen.getByText("Calculate fee");
     fireEvent.click(calcBtn);
@@ -113,7 +135,7 @@ describe("CreateProposalModal", () => {
       expect(screen.getByText("Could not estimate fee")).toBeDefined();
     });
 
-    const submitBtn = screen.getByText("Submit Proposal");
+    const submitBtn = screen.getByText("Review Proposal");
     fireEvent.click(submitBtn);
 
     expect(screen.getByText("Preview Proposal")).toBeDefined();
@@ -129,7 +151,7 @@ describe("CreateProposalModal", () => {
 
   it("shows a preview with entered values before submitting", () => {
     render(<CreateProposalModal {...defaultProps} />);
-    fillRequiredFields();
+    fillTransferFields();
 
     const deadlineInput = document.querySelector(
       'input[type="date"]'
@@ -142,11 +164,10 @@ describe("CreateProposalModal", () => {
       day: "numeric",
     });
 
-    fireEvent.click(screen.getByText("Submit Proposal"));
+    fireEvent.click(screen.getByText("Review Proposal"));
 
     expect(screen.getByText("Preview Proposal")).toBeDefined();
-    expect(screen.getByText("GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4IQDNC")).toBeDefined();
-    expect(screen.getByText("10 XLM")).toBeDefined();
+    expect(screen.getByText("Transfer 10 XLM to GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4IQDNC")).toBeDefined();
     expect(screen.getByText("Test payment")).toBeDefined();
     expect(screen.getByText(expectedDeadline)).toBeDefined();
     expect(createProposal).not.toHaveBeenCalled();
@@ -154,9 +175,9 @@ describe("CreateProposalModal", () => {
 
   it("Back returns to the form with entered values preserved", () => {
     render(<CreateProposalModal {...defaultProps} />);
-    fillRequiredFields();
+    fillTransferFields();
 
-    fireEvent.click(screen.getByText("Submit Proposal"));
+    fireEvent.click(screen.getByText("Review Proposal"));
     fireEvent.click(screen.getByText("Back"));
 
     expect(screen.queryByText("Preview Proposal")).toBeNull();
@@ -171,9 +192,9 @@ describe("CreateProposalModal", () => {
 
   it("Close button works from the preview step", () => {
     render(<CreateProposalModal {...defaultProps} />);
-    fillRequiredFields();
+    fillTransferFields();
 
-    fireEvent.click(screen.getByText("Submit Proposal"));
+    fireEvent.click(screen.getByText("Review Proposal"));
     fireEvent.click(screen.getByText("✕"));
 
     expect(defaultProps.onClose).toHaveBeenCalled();
@@ -181,12 +202,34 @@ describe("CreateProposalModal", () => {
 
   it("Connected wallet opens modal and shows Proposer field", () => {
     render(<CreateProposalModal {...defaultProps} />);
+    selectTransfer();
     expect(screen.getByText("Proposer")).toBeDefined();
   });
 
   it("Address is truncated to first 6 and last 4", () => {
     render(<CreateProposalModal {...defaultProps} />);
+    selectTransfer();
     // Truncated version: GDHU6W…QDNC
     expect(screen.getByText("GDHU6W…QDNC")).toBeDefined();
+  });
+
+  it("shows type selector on mount", () => {
+    render(<CreateProposalModal {...defaultProps} />);
+    expect(screen.getByText("Transfer")).toBeDefined();
+    expect(screen.getByText("Add Owner")).toBeDefined();
+    expect(screen.getByText("Remove Owner")).toBeDefined();
+    expect(screen.getByText("Change Threshold")).toBeDefined();
+  });
+
+  it("Add Owner flow shows owner address input", () => {
+    render(<CreateProposalModal {...defaultProps} />);
+    fireEvent.click(screen.getByText("Add Owner"));
+    expect(screen.getByText("New Owner Address")).toBeDefined();
+  });
+
+  it("Change Threshold flow shows threshold input with owner count", () => {
+    render(<CreateProposalModal {...defaultProps} />);
+    fireEvent.click(screen.getByText("Change Threshold"));
+    expect(screen.getByText(/New Threshold/)).toBeDefined();
   });
 });

--- a/frontend/src/components/CreateProposalModal.tsx
+++ b/frontend/src/components/CreateProposalModal.tsx
@@ -1,7 +1,15 @@
 import { useState, useEffect, useRef, type RefObject } from "react";
-import { createProposal, estimateCreateProposalFee } from "../lib/submit";
+import {
+  createProposal,
+  createAddOwnerProposal,
+  createRemoveOwnerProposal,
+  createChangeThresholdProposal,
+  estimateCreateProposalFee,
+} from "../lib/submit";
+import { getOwners, getThreshold } from "../lib/contract";
 import { displayToStroops } from "../lib/soroban";
 import { StrKey } from "@stellar/stellar-sdk";
+import type { ProposalKind } from "../types/accord";
 // Testnet token addresses — swap for mainnet when ready
 const TOKEN_ADDRESSES: Record<string, string> = {
   XLM: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
@@ -14,23 +22,74 @@ type Props = {
   walletAddress: string | null;
   onClose: () => void;
   onSubmitted: () => void;
-  /** Ref to the button that triggered this modal — focus is returned to it on close. */
   triggerRef?: RefObject<HTMLButtonElement | null>;
 };
 
-type ProposalStep = "form" | "preview";
+type ProposalStep = "type" | "form" | "preview";
+
+type FormType = ProposalKind;
+
+type TransferFormData = {
+  type: "transfer";
+  recipient: string;
+  tokenAddr: string;
+  amountStroops: bigint;
+  description: string;
+  deadlineUnix: bigint;
+};
+
+type AddOwnerFormData = {
+  type: "add_owner";
+  newOwner: string;
+  description: string;
+  deadlineUnix: bigint;
+};
+
+type RemoveOwnerFormData = {
+  type: "remove_owner";
+  ownerToRemove: string;
+  description: string;
+  deadlineUnix: bigint;
+};
+
+type ChangeThresholdFormData = {
+  type: "change_threshold";
+  newThreshold: number;
+  description: string;
+  deadlineUnix: bigint;
+};
+
+type ValidatedFormData = TransferFormData | AddOwnerFormData | RemoveOwnerFormData | ChangeThresholdFormData;
+
+const FORM_OPTIONS: { kind: FormType; label: string }[] = [
+  { kind: "transfer", label: "Transfer" },
+  { kind: "add_owner", label: "Add Owner" },
+  { kind: "remove_owner", label: "Remove Owner" },
+  { kind: "change_threshold", label: "Change Threshold" },
+];
 
 function truncateAddress(address: string | null) {
   if (!address) return "Not connected";
   return `${address.slice(0, 6)}…${address.slice(-4)}`;
 }
 
-function formatDeadline(deadline: string) {
+function formatDeadlineDate(deadline: string) {
   return new Date(`${deadline}T00:00:00`).toLocaleDateString(undefined, {
     year: "numeric",
     month: "long",
     day: "numeric",
   });
+}
+
+function validateDeadline(deadline: string): string | null {
+  const deadlineMs = new Date(deadline).getTime();
+  const nowMs = Date.now();
+  const todayMidnight = new Date();
+  todayMidnight.setHours(0, 0, 0, 0);
+  if (deadlineMs <= todayMidnight.getTime()) return "Deadline must be in the future.";
+  const maxMs = nowMs + 90 * 24 * 3600 * 1000;
+  if (deadlineMs > maxMs) return "Deadline cannot be more than 90 days away.";
+  return null;
 }
 
 export function CreateProposalModal({ walletAddress, onClose, onSubmitted, triggerRef }: Props) {
@@ -40,33 +99,65 @@ export function CreateProposalModal({ walletAddress, onClose, onSubmitted, trigg
     return d.toISOString().slice(0, 10);
   };
 
+  // Flow
+  const [step, setStep] = useState<ProposalStep>("type");
+  const [formType, setFormType] = useState<FormType>("transfer");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Common fields
+  const [description, setDescription] = useState("");
+  const [deadline, setDeadline] = useState(defaultDeadline);
+
+  // Transfer fields
   const [to, setTo] = useState("");
   const [recipientTouched, setRecipientTouched] = useState(false);
   const [amount, setAmount] = useState("");
   const [token, setToken] = useState("XLM");
-  const [description, setDescription] = useState("");
-  const [deadline, setDeadline] = useState(defaultDeadline);
-  const [step, setStep] = useState<ProposalStep>("form");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
+  // Add/Remove Owner fields
+  const [ownerAddress, setOwnerAddress] = useState("");
+  const [ownerTouched, setOwnerTouched] = useState(false);
+  const [availableOwners, setAvailableOwners] = useState<string[]>([]);
+  const [selectedOwner, setSelectedOwner] = useState("");
+
+  // Change Threshold fields
+  const [newThreshold, setNewThreshold] = useState("");
+  const [currentThreshold, setCurrentThreshold] = useState<number>(1);
+  const [totalOwners, setTotalOwners] = useState<number>(1);
+
+  // Fee
   const [feeEstimate, setFeeEstimate] = useState<number | null>(null);
   const [feeLoading, setFeeLoading] = useState(false);
   const [feeError, setFeeError] = useState(false);
 
-  const recipientInputRef = useRef<HTMLInputElement>(null);
+  const firstInputRef = useRef<HTMLInputElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
 
-  // Initial focus: move to the recipient input on mount.
-  // On unmount, restore focus to the triggering element (or whatever was active before).
+  // Load contract data for governance proposals
+  useEffect(() => {
+    if (formType === "remove_owner" || formType === "change_threshold") {
+      getOwners()
+        .then(setAvailableOwners)
+        .catch(() => setAvailableOwners([]));
+    }
+    if (formType === "change_threshold") {
+      Promise.all([getThreshold(), getOwners()])
+        .then(([thresh, owners]) => {
+          setCurrentThreshold(thresh);
+          setTotalOwners(owners.length);
+        })
+        .catch(() => {});
+    }
+  }, [formType]);
+
+  // Initial focus
   useEffect(() => {
     const previousActiveElement = document.activeElement as HTMLElement | null;
-    if (recipientInputRef.current) {
-      recipientInputRef.current.focus();
+    if (firstInputRef.current) {
+      firstInputRef.current.focus();
     }
-
     return () => {
-      // Prefer the explicit trigger ref; fall back to whatever had focus before mount.
       if (triggerRef?.current && typeof triggerRef.current.focus === "function") {
         triggerRef.current.focus();
       } else if (previousActiveElement && typeof previousActiveElement.focus === "function") {
@@ -76,7 +167,7 @@ export function CreateProposalModal({ walletAddress, onClose, onSubmitted, trigg
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Focus trap: confine Tab / Shift+Tab within the modal; Escape closes it.
+  // Focus trap
   useEffect(() => {
     const modal = modalRef.current;
     if (!modal) return;
@@ -90,7 +181,6 @@ export function CreateProposalModal({ walletAddress, onClose, onSubmitted, trigg
         onClose();
         return;
       }
-
       if (e.key !== "Tab") return;
 
       const focusable = Array.from(
@@ -106,13 +196,11 @@ export function CreateProposalModal({ walletAddress, onClose, onSubmitted, trigg
       const last = focusable[focusable.length - 1];
 
       if (e.shiftKey) {
-        // Shift+Tab: wrap backward from first → last
         if (document.activeElement === first) {
           e.preventDefault();
           last.focus();
         }
       } else {
-        // Tab: wrap forward from last → first
         if (document.activeElement === last) {
           e.preventDefault();
           first.focus();
@@ -124,22 +212,126 @@ export function CreateProposalModal({ walletAddress, onClose, onSubmitted, trigg
     return () => modal.removeEventListener("keydown", handleKeyDown);
   }, [onClose]);
 
-  const canCalculateFee = Boolean(
-    walletAddress && to.trim() && amount.trim() && description.trim()
-  );
+  function clearError() {
+    setError(null);
+  }
+
+  // ─── Validation ──────────────────────────────────────────────────────────
+
+  function getValidatedForm(): ValidatedFormData | null {
+    if (!walletAddress) {
+      setError("Connect your wallet first.");
+      return null;
+    }
+
+    if (formType === "transfer") {
+      if (!to.trim() || !amount.trim() || !description.trim()) {
+        setError("Recipient, amount, and description are required.");
+        return null;
+      }
+      if (!StrKey.isValidEd25519PublicKey(to.trim())) {
+        setError("Enter a valid Stellar address");
+        return null;
+      }
+      const amountNum = parseFloat(amount);
+      if (isNaN(amountNum) || amountNum <= 0) {
+        setError("Enter a valid amount.");
+        return null;
+      }
+      const tokenAddr = TOKEN_ADDRESSES[token];
+      if (!tokenAddr) {
+        setError("Unknown token.");
+        return null;
+      }
+      const dlErr = validateDeadline(deadline);
+      if (dlErr) { setError(dlErr); return null; }
+
+      return {
+        type: "transfer",
+        recipient: to.trim(),
+        tokenAddr,
+        amountStroops: displayToStroops(amountNum),
+        description: description.trim(),
+        deadlineUnix: BigInt(Math.floor(new Date(deadline).getTime() / 1000)),
+      } satisfies TransferFormData;
+    }
+
+    if (formType === "add_owner") {
+      if (!ownerAddress.trim() || !description.trim()) {
+        setError("Owner address and description are required.");
+        return null;
+      }
+      if (!StrKey.isValidEd25519PublicKey(ownerAddress.trim())) {
+        setError("Enter a valid Stellar address");
+        return null;
+      }
+      const dlErr = validateDeadline(deadline);
+      if (dlErr) { setError(dlErr); return null; }
+
+      return {
+        type: "add_owner",
+        newOwner: ownerAddress.trim(),
+        description: description.trim(),
+        deadlineUnix: BigInt(Math.floor(new Date(deadline).getTime() / 1000)),
+      } satisfies AddOwnerFormData;
+    }
+
+    if (formType === "remove_owner") {
+      if (!selectedOwner) {
+        setError("Select an owner to remove.");
+        return null;
+      }
+      if (!description.trim()) {
+        setError("Description is required.");
+        return null;
+      }
+      const dlErr = validateDeadline(deadline);
+      if (dlErr) { setError(dlErr); return null; }
+
+      return {
+        type: "remove_owner",
+        ownerToRemove: selectedOwner,
+        description: description.trim(),
+        deadlineUnix: BigInt(Math.floor(new Date(deadline).getTime() / 1000)),
+      } satisfies RemoveOwnerFormData;
+    }
+
+    if (formType === "change_threshold") {
+      const val = parseInt(newThreshold, 10);
+      if (isNaN(val) || val < 1 || val > totalOwners) {
+        setError(`Threshold must be between 1 and ${totalOwners}.`);
+        return null;
+      }
+      if (!description.trim()) {
+        setError("Description is required.");
+        return null;
+      }
+      const dlErr = validateDeadline(deadline);
+      if (dlErr) { setError(dlErr); return null; }
+
+      return {
+        type: "change_threshold",
+        newThreshold: val,
+        description: description.trim(),
+        deadlineUnix: BigInt(Math.floor(new Date(deadline).getTime() / 1000)),
+      } satisfies ChangeThresholdFormData;
+    }
+
+    setError("Unknown proposal type.");
+    return null;
+  }
 
   async function handleCalculateFee() {
-    if (!canCalculateFee) return;
-
-    const amountNum = parseFloat(amount);
-    if (isNaN(amountNum) || amountNum <= 0) return;
+    if (formType !== "transfer") return;
+    if (!walletAddress || !to.trim() || !amount.trim() || !description.trim()) return;
 
     const tokenAddr = TOKEN_ADDRESSES[token];
     if (!tokenAddr) return;
 
-    const deadlineMs = new Date(deadline).getTime();
-    const deadlineUnix = BigInt(Math.floor(deadlineMs / 1000));
-    const amountStroops = displayToStroops(amountNum);
+    const amountNum = parseFloat(amount);
+    if (isNaN(amountNum) || amountNum <= 0) return;
+
+    const deadlineUnix = BigInt(Math.floor(new Date(deadline).getTime() / 1000));
 
     setFeeLoading(true);
     setFeeError(false);
@@ -147,94 +339,77 @@ export function CreateProposalModal({ walletAddress, onClose, onSubmitted, trigg
 
     try {
       const fee = await estimateCreateProposalFee(
-        walletAddress as string,
+        walletAddress,
         to.trim(),
         tokenAddr,
-        amountStroops,
+        displayToStroops(amountNum),
         description.trim(),
         deadlineUnix
       );
       setFeeEstimate(fee);
-    } catch (e) {
+    } catch {
       setFeeError(true);
     } finally {
       setFeeLoading(false);
     }
   }
 
-  function getValidatedProposal() {
-    if (!walletAddress) {
-      setError("Connect your wallet first.");
-      return null;
-    }
-    if (!to.trim() || !amount.trim() || !description.trim()) {
-      setError("Recipient, amount, and description are required.");
-      return null;
-    }
-
-    if (!StrKey.isValidEd25519PublicKey(to.trim())) {
-      setError("Enter a valid Stellar address");
-      return null;
-    }
-
-    const amountNum = parseFloat(amount);
-    if (isNaN(amountNum) || amountNum <= 0) {
-      setError("Enter a valid amount.");
-      return null;
-    }
-
-    const tokenAddr = TOKEN_ADDRESSES[token];
-    if (!tokenAddr) {
-      setError("Unknown token.");
-      return null;
-    }
-
-    const deadlineMs = new Date(deadline).getTime();
-    const nowMs = Date.now();
-    const todayMidnight = new Date();
-    todayMidnight.setHours(0, 0, 0, 0);
-    if (deadlineMs <= todayMidnight.getTime()) {
-      setError("Deadline must be in the future.");
-      return null;
-    }
-    const maxMs = nowMs + 90 * 24 * 3600 * 1000;
-    if (deadlineMs > maxMs) {
-      setError("Deadline cannot be more than 90 days away.");
-      return null;
-    }
-
-    return {
-      recipient: to.trim(),
-      tokenAddr,
-      amountStroops: displayToStroops(amountNum),
-      description: description.trim(),
-      deadlineUnix: BigInt(Math.floor(deadlineMs / 1000)),
-    };
+  function handleGoToForm(kind: FormType) {
+    clearError();
+    setFormType(kind);
+    setStep("form");
   }
 
   function handleSubmit() {
-    const proposal = getValidatedProposal();
-    if (!proposal) return;
-
-    setError(null);
+    const data = getValidatedForm();
+    if (!data) return;
+    clearError();
     setStep("preview");
   }
 
   async function handleConfirmSubmit() {
-    const proposal = getValidatedProposal();
-    if (!proposal) return;
+    const data = getValidatedForm();
+    if (!data) return;
 
-    setError(null);
+    clearError();
     setSubmitting(true);
     try {
-      await createProposal(
-        walletAddress as string,
-        proposal.recipient,
-        proposal.tokenAddr,
-        proposal.amountStroops,
-        proposal.description,
-        proposal.deadlineUnix
-      );
+      switch (data.type) {
+        case "transfer":
+          await createProposal(
+            walletAddress!,
+            data.recipient,
+            data.tokenAddr,
+            data.amountStroops,
+            data.description,
+            data.deadlineUnix
+          );
+          break;
+        case "add_owner":
+          await createAddOwnerProposal(
+            walletAddress!,
+            data.newOwner,
+            data.description,
+            data.deadlineUnix
+          );
+          break;
+        case "remove_owner":
+          await createRemoveOwnerProposal(
+            walletAddress!,
+            data.ownerToRemove,
+            data.description,
+            data.deadlineUnix
+          );
+          break;
+        case "change_threshold":
+          await createChangeThresholdProposal(
+            walletAddress!,
+            data.newThreshold,
+            data.description,
+            data.deadlineUnix
+          );
+          break;
+      }
       onSubmitted();
       onClose();
     } catch (e) {
@@ -242,6 +417,356 @@ export function CreateProposalModal({ walletAddress, onClose, onSubmitted, trigg
     } finally {
       setSubmitting(false);
     }
+  }
+
+  // ─── Render steps ────────────────────────────────────────────────────────
+
+  function renderTypeSelector() {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-zinc-400">Select the type of proposal to create:</p>
+        <div className="grid grid-cols-2 gap-3">
+          {FORM_OPTIONS.map(({ kind, label }) => (
+            <button
+              key={kind}
+              type="button"
+              onClick={() => handleGoToForm(kind)}
+              className="rounded-xl border border-zinc-700 bg-zinc-800/50 p-4 text-sm font-medium text-zinc-200 transition-colors hover:border-emerald-500/50 hover:bg-zinc-800 disabled:opacity-50 focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  function renderForm() {
+    return (
+      <>
+        <div>
+          <label className="text-xs text-zinc-400 block mb-1.5">Proposer</label>
+          <div
+            className={`w-full border rounded-lg px-3 py-2.5 text-sm ${
+              walletAddress
+                ? "bg-zinc-800/60 border-zinc-700/60 text-zinc-300 font-mono"
+                : "bg-zinc-800/30 border-zinc-700/30 text-zinc-500"
+            } truncate`}
+          >
+            {truncateAddress(walletAddress)}
+          </div>
+        </div>
+
+        {/* Transfer specific fields */}
+        {formType === "transfer" && (
+          <>
+            <div>
+              <label className="text-xs text-zinc-400 block mb-1.5">
+                Recipient Address
+              </label>
+              <input
+                ref={firstInputRef}
+                value={to}
+                onChange={(e) => {
+                  setTo(e.target.value);
+                  setRecipientTouched(true);
+                }}
+                onBlur={() => setRecipientTouched(true)}
+                placeholder="G..."
+                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm font-mono placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+              />
+              {recipientTouched && !StrKey.isValidEd25519PublicKey(to.trim()) && (
+                <p className="text-xs text-red-400 mt-1">Enter a valid Stellar address</p>
+              )}
+            </div>
+
+            <div className="flex gap-3">
+              <div className="flex-1">
+                <label className="text-xs text-zinc-400 block mb-1.5">Amount</label>
+                <input
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  placeholder="0.00"
+                  type="number"
+                  min="0"
+                  step="any"
+                  className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+                />
+              </div>
+              <div className="w-28">
+                <label className="text-xs text-zinc-400 block mb-1.5">Token</label>
+                <div className="grid grid-cols-3 gap-1">
+                  {(["XLM", "USDC", "EURC"] as const).map((symbol) => {
+                    const active = token === symbol;
+                    return (
+                      <button
+                        key={symbol}
+                        type="button"
+                        onClick={() => setToken(symbol)}
+                        aria-pressed={active}
+                        className={`rounded-lg border px-1.5 py-2 text-xs font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none ${
+                          active
+                            ? "border-emerald-500 bg-emerald-500/20 text-emerald-300"
+                            : "border-zinc-700 bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
+                        }`}
+                      >
+                        {symbol}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+
+            {walletAddress && to.trim() && amount.trim() && description.trim() && (
+              <div className="flex items-center justify-between bg-zinc-800/50 p-3 rounded-lg border border-zinc-700/50">
+                <div className="text-sm">
+                  {feeLoading ? (
+                    <span className="text-zinc-400">Estimating fee…</span>
+                  ) : feeError ? (
+                    <span className="text-red-400">Could not estimate fee</span>
+                  ) : feeEstimate !== null ? (
+                    <span className="text-zinc-300">
+                      Estimated fee: <span className="text-white font-mono">~{feeEstimate.toFixed(7)} XLM</span>
+                    </span>
+                  ) : (
+                    <span className="text-zinc-500">No estimate yet</span>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={handleCalculateFee}
+                  disabled={feeLoading}
+                  className="text-xs bg-zinc-700 hover:bg-zinc-600 disabled:opacity-50 text-white px-3 py-1.5 rounded-md transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+                >
+                  Calculate fee
+                </button>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Add Owner fields */}
+        {formType === "add_owner" && (
+          <div>
+            <label className="text-xs text-zinc-400 block mb-1.5">
+              New Owner Address
+            </label>
+            <input
+              ref={firstInputRef}
+              value={ownerAddress}
+              onChange={(e) => {
+                setOwnerAddress(e.target.value);
+                setOwnerTouched(true);
+              }}
+              onBlur={() => setOwnerTouched(true)}
+              placeholder="G..."
+              className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm font-mono placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+            />
+            {ownerTouched && !StrKey.isValidEd25519PublicKey(ownerAddress.trim()) && (
+              <p className="text-xs text-red-400 mt-1">Enter a valid Stellar address</p>
+            )}
+          </div>
+        )}
+
+        {/* Remove Owner fields */}
+        {formType === "remove_owner" && (
+          <div>
+            <label className="text-xs text-zinc-400 block mb-1.5">
+              Owner to Remove
+            </label>
+            <select
+              ref={firstInputRef as unknown as React.Ref<HTMLSelectElement>}
+              value={selectedOwner}
+              onChange={(e) => setSelectedOwner(e.target.value)}
+              className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm font-mono focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+            >
+              <option value="">Select an owner…</option>
+              {availableOwners.map((addr) => (
+                <option key={addr} value={addr}>
+                  {truncateAddress(addr)}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {/* Change Threshold fields */}
+        {formType === "change_threshold" && (
+          <div>
+            <label className="text-xs text-zinc-400 block mb-1.5">
+              New Threshold (currently {currentThreshold} of {totalOwners})
+            </label>
+            <input
+              ref={firstInputRef}
+              value={newThreshold}
+              onChange={(e) => setNewThreshold(e.target.value)}
+              placeholder={`1 – ${totalOwners}`}
+              type="number"
+              min={1}
+              max={totalOwners}
+              className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm font-mono placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+            />
+            <p className="text-xs text-zinc-500 mt-1">
+              Threshold must be between 1 and {totalOwners}
+            </p>
+          </div>
+        )}
+
+        {/* Common fields */}
+        <div>
+          <label className="text-xs text-zinc-400 block mb-1.5">
+            Description
+          </label>
+          <input
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            maxLength={MAX_DESCRIPTION_LEN}
+            placeholder={formType === "transfer" ? "What is this payment for?" : "Reason for this change"}
+            className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+          />
+          <p
+            className={`mt-1 text-right text-xs ${
+              description.length >= MAX_DESCRIPTION_LEN
+                ? "text-red-400"
+                : "text-zinc-500"
+            }`}
+          >
+            {description.length} / {MAX_DESCRIPTION_LEN}
+          </p>
+        </div>
+
+        <div>
+          <label className="text-xs text-zinc-400 block mb-1.5">
+            Deadline
+          </label>
+          <input
+            type="date"
+            value={deadline}
+            onChange={(e) => setDeadline(e.target.value)}
+            className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+          />
+        </div>
+
+        {error && (
+          <p className="text-xs text-red-400 bg-red-500/10 rounded-lg px-3 py-2">
+            {error}
+          </p>
+        )}
+
+        <div className="flex gap-3 pt-2">
+          <button
+            type="button"
+            onClick={() => setStep("type")}
+            className="flex-1 bg-zinc-800 hover:bg-zinc-700 text-white py-2.5 rounded-lg font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting || !walletAddress}
+            title={
+              walletAddress ? undefined : "Connect your Freighter wallet to submit"
+            }
+            className="flex-1 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white py-2.5 rounded-lg font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+          >
+            Review Proposal
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  function renderPreview() {
+    const dl = formatDeadlineDate(deadline);
+    return (
+      <>
+        <div className="space-y-3">
+          <h3 className="text-sm font-medium text-zinc-200">Preview Proposal</h3>
+          <dl className="space-y-3 rounded-lg border border-zinc-700 bg-zinc-800/50 p-3">
+            {formType === "transfer" && (
+              <>
+                <div>
+                  <dt className="text-xs text-zinc-500">Action</dt>
+                  <dd className="mt-1 text-sm text-zinc-200">Transfer {amount} {token} to {to}</dd>
+                </div>
+              </>
+            )}
+            {formType === "add_owner" && (
+              <>
+                <div>
+                  <dt className="text-xs text-zinc-500">Action</dt>
+                  <dd className="mt-1 text-sm text-zinc-200">Add new owner</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-zinc-500">New Owner Address</dt>
+                  <dd className="mt-1 break-all font-mono text-sm text-zinc-200">{ownerAddress.trim()}</dd>
+                </div>
+              </>
+            )}
+            {formType === "remove_owner" && (
+              <>
+                <div>
+                  <dt className="text-xs text-zinc-500">Action</dt>
+                  <dd className="mt-1 text-sm text-zinc-200">Remove owner</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-zinc-500">Owner to Remove</dt>
+                  <dd className="mt-1 break-all font-mono text-sm text-zinc-200">{selectedOwner}</dd>
+                </div>
+              </>
+            )}
+            {formType === "change_threshold" && (
+              <>
+                <div>
+                  <dt className="text-xs text-zinc-500">Action</dt>
+                  <dd className="mt-1 text-sm text-zinc-200">Change approval threshold to {newThreshold} of {totalOwners}</dd>
+                </div>
+              </>
+            )}
+            <div>
+              <dt className="text-xs text-zinc-500">Description</dt>
+              <dd className="mt-1 whitespace-pre-wrap break-words text-sm text-zinc-200">
+                {description.trim()}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-zinc-500">Deadline</dt>
+              <dd className="mt-1 text-sm text-zinc-200">{dl}</dd>
+            </div>
+          </dl>
+        </div>
+
+        {error && (
+          <p className="text-xs text-red-400 bg-red-500/10 rounded-lg px-3 py-2">
+            {error}
+          </p>
+        )}
+
+        <div className="flex gap-3 pt-2">
+          <button
+            type="button"
+            onClick={() => setStep("form")}
+            disabled={submitting}
+            className="flex-1 bg-zinc-800 hover:bg-zinc-700 disabled:opacity-50 text-white py-2.5 rounded-lg font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirmSubmit}
+            disabled={submitting || !walletAddress}
+            title={
+              walletAddress ? undefined : "Connect your Freighter wallet to submit"
+            }
+            className="flex-1 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white py-2.5 rounded-lg font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+          >
+            {submitting ? "Submitting…" : "Confirm & Submit"}
+          </button>
+        </div>
+      </>
+    );
   }
 
   return (
@@ -268,223 +793,9 @@ export function CreateProposalModal({ walletAddress, onClose, onSubmitted, trigg
         </div>
 
         <div className="space-y-4">
-          {step === "form" ? (
-            <>
-              <div>
-                <label className="text-xs text-zinc-400 block mb-1.5">
-                  Proposer
-                </label>
-                <div
-                  className={`w-full border rounded-lg px-3 py-2.5 text-sm ${
-                    walletAddress
-                      ? "bg-zinc-800/60 border-zinc-700/60 text-zinc-300 font-mono"
-                      : "bg-zinc-800/30 border-zinc-700/30 text-zinc-500"
-                  } truncate`}
-                >
-                  {truncateAddress(walletAddress)}
-                </div>
-              </div>
-
-              <div>
-                <label className="text-xs text-zinc-400 block mb-1.5">
-                  Recipient Address
-                </label>
-                <input
-                  ref={recipientInputRef}
-                  value={to}
-                  onChange={(e) => {
-                    setTo(e.target.value);
-                    setRecipientTouched(true);
-                  }}
-                  onBlur={() => setRecipientTouched(true)}
-                  placeholder="G..."
-                  className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm font-mono placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
-                />
-                {recipientTouched && !StrKey.isValidEd25519PublicKey(to.trim()) && (
-                  <p className="text-xs text-red-400 mt-1">Enter a valid Stellar address</p>
-                )}
-              </div>
-
-              <div className="flex gap-3">
-                <div className="flex-1">
-                  <label className="text-xs text-zinc-400 block mb-1.5">Amount</label>
-                  <input
-                    value={amount}
-                    onChange={(e) => setAmount(e.target.value)}
-                    placeholder="0.00"
-                    type="number"
-                    min="0"
-                    step="any"
-                    className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
-                  />
-                </div>
-                <div className="w-28">
-                  <label className="text-xs text-zinc-400 block mb-1.5">Token</label>
-                  <div className="grid grid-cols-3 gap-1">
-                    {(["XLM", "USDC", "EURC"] as const).map((symbol) => {
-                      const active = token === symbol;
-
-                      return (
-                        <button
-                          key={symbol}
-                          type="button"
-                          onClick={() => setToken(symbol)}
-                          aria-pressed={active}
-                          className={`rounded-lg border px-1.5 py-2 text-xs font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none ${
-                            active
-                              ? "border-emerald-500 bg-emerald-500/20 text-emerald-300"
-                              : "border-zinc-700 bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
-                          }`}
-                        >
-                          {symbol}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              </div>
-
-              <div>
-                <label className="text-xs text-zinc-400 block mb-1.5">
-                  Description
-                </label>
-                <input
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  maxLength={MAX_DESCRIPTION_LEN}
-                  placeholder="What is this payment for?"
-                  className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
-                />
-                <p
-                  className={`mt-1 text-right text-xs ${
-                    description.length >= MAX_DESCRIPTION_LEN
-                      ? "text-red-400"
-                      : "text-zinc-500"
-                  }`}
-                >
-                  {description.length} / {MAX_DESCRIPTION_LEN}
-                </p>
-              </div>
-
-              <div>
-                <label className="text-xs text-zinc-400 block mb-1.5">
-                  Deadline
-                </label>
-                <input
-                  type="date"
-                  value={deadline}
-                  onChange={(e) => setDeadline(e.target.value)}
-                  className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
-                />
-              </div>
-
-              {canCalculateFee && (
-                <div className="flex items-center justify-between bg-zinc-800/50 p-3 rounded-lg border border-zinc-700/50">
-                  <div className="text-sm">
-                    {feeLoading ? (
-                      <span className="text-zinc-400">Estimating fee…</span>
-                    ) : feeError ? (
-                      <span className="text-red-400">Could not estimate fee</span>
-                    ) : feeEstimate !== null ? (
-                      <span className="text-zinc-300">
-                        Estimated fee: <span className="text-white font-mono">~{feeEstimate.toFixed(7)} XLM</span>
-                      </span>
-                    ) : (
-                      <span className="text-zinc-500">No estimate yet</span>
-                    )}
-                  </div>
-                  <button
-                    type="button"
-                    onClick={handleCalculateFee}
-                    disabled={feeLoading}
-                    className="text-xs bg-zinc-700 hover:bg-zinc-600 disabled:opacity-50 text-white px-3 py-1.5 rounded-md transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
-                  >
-                    Calculate fee
-                  </button>
-                </div>
-              )}
-
-              {error && (
-                <p className="text-xs text-red-400 bg-red-500/10 rounded-lg px-3 py-2">
-                  {error}
-                </p>
-              )}
-
-              <div className="pt-2">
-                <button
-                  type="button"
-                  onClick={handleSubmit}
-                  disabled={submitting || !walletAddress}
-                  title={
-                    walletAddress ? undefined : "Connect your Freighter wallet to submit"
-                  }
-                  className="w-full bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white py-2.5 rounded-lg font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
-                >
-                  Submit Proposal
-                </button>
-              </div>
-            </>
-          ) : (
-            <>
-              <div className="space-y-3">
-                <h3 className="text-sm font-medium text-zinc-200">Preview Proposal</h3>
-                <dl className="space-y-3 rounded-lg border border-zinc-700 bg-zinc-800/50 p-3">
-                  <div>
-                    <dt className="text-xs text-zinc-500">Recipient Address</dt>
-                    <dd className="mt-1 break-all font-mono text-sm text-zinc-200">
-                      {to.trim()}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="text-xs text-zinc-500">Amount</dt>
-                    <dd className="mt-1 text-sm text-zinc-200">
-                      {amount.trim()} {token}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="text-xs text-zinc-500">Description</dt>
-                    <dd className="mt-1 whitespace-pre-wrap break-words text-sm text-zinc-200">
-                      {description.trim()}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="text-xs text-zinc-500">Deadline</dt>
-                    <dd className="mt-1 text-sm text-zinc-200">
-                      {formatDeadline(deadline)}
-                    </dd>
-                  </div>
-                </dl>
-              </div>
-
-              {error && (
-                <p className="text-xs text-red-400 bg-red-500/10 rounded-lg px-3 py-2">
-                  {error}
-                </p>
-              )}
-
-              <div className="flex gap-3 pt-2">
-                <button
-                  type="button"
-                  onClick={() => setStep("form")}
-                  disabled={submitting}
-                  className="flex-1 bg-zinc-800 hover:bg-zinc-700 disabled:opacity-50 text-white py-2.5 rounded-lg font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
-                >
-                  Back
-                </button>
-                <button
-                  type="button"
-                  onClick={handleConfirmSubmit}
-                  disabled={submitting || !walletAddress}
-                  title={
-                    walletAddress ? undefined : "Connect your Freighter wallet to submit"
-                  }
-                  className="flex-1 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white py-2.5 rounded-lg font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
-                >
-                  {submitting ? "Submitting…" : "Confirm & Submit"}
-                </button>
-              </div>
-            </>
-          )}
+          {step === "type" && renderTypeSelector()}
+          {step === "form" && renderForm()}
+          {step === "preview" && renderPreview()}
         </div>
       </div>
     </div>

--- a/frontend/src/components/ProposalCard.test.tsx
+++ b/frontend/src/components/ProposalCard.test.tsx
@@ -20,6 +20,7 @@ vi.mock("../hooks/useContract", () => ({
 
 const baseProposal = (overrides: Partial<Proposal> = {}): Proposal => ({
   id: 42,
+  kind: "transfer",
   to: "GABCDE...WXYZ",
   amount: "100",
   token: "USDC",

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
-import type { Proposal } from "../types/accord";
+import type { Proposal, ProposalKind } from "../types/accord";
 import { ApprovalBar } from "./ApprovalBar";
 import { StatusBadge } from "./StatusBadge";
 import { Check, Copy, Link2 } from "lucide-react";
@@ -12,6 +12,104 @@ type ProposalCardProps = {
   onExecute: (id: number) => void;
   onRevoke: (id: number) => void;
 };
+
+const KIND_LABELS: Record<ProposalKind, { title: string; badge: string }> = {
+  transfer: { title: "Send", badge: "Transfer" },
+  add_owner: { title: "Add Owner", badge: "Governance" },
+  remove_owner: { title: "Remove Owner", badge: "Governance" },
+  change_threshold: { title: "Change Threshold", badge: "Governance" },
+  set_spending_limit: { title: "Set Spending Limit", badge: "Spending Limit" },
+};
+
+function KindSummary({ proposal }: { proposal: Proposal }): ReactNode {
+  const { kind } = proposal;
+
+  switch (kind) {
+    case "transfer":
+      return (
+        <>
+          <Link
+            to={`/proposals/${proposal.id}`}
+            className="font-semibold text-white transition-colors hover:text-emerald-300 focus:outline-none focus:ring-2 focus:ring-zinc-400 rounded"
+          >
+            Send {proposal.amount} {proposal.token}
+          </Link>
+          <p className="text-zinc-500 text-sm font-mono mt-0.5">
+            →{" "}
+            <span className="inline-block max-w-[180px] truncate align-bottom">
+              {proposal.to}
+            </span>
+          </p>
+        </>
+      );
+    case "add_owner":
+      return (
+        <>
+          <Link
+            to={`/proposals/${proposal.id}`}
+            className="font-semibold text-white transition-colors hover:text-emerald-300 focus:outline-none focus:ring-2 focus:ring-zinc-400 rounded"
+          >
+            Add Owner
+          </Link>
+          <p className="text-zinc-500 text-sm font-mono mt-0.5">
+            New owner →{" "}
+            <span className="inline-block max-w-[180px] truncate align-bottom">
+              {proposal.to}
+            </span>
+          </p>
+        </>
+      );
+    case "remove_owner":
+      return (
+        <>
+          <Link
+            to={`/proposals/${proposal.id}`}
+            className="font-semibold text-white transition-colors hover:text-emerald-300 focus:outline-none focus:ring-2 focus:ring-zinc-400 rounded"
+          >
+            Remove Owner
+          </Link>
+          <p className="text-zinc-500 text-sm font-mono mt-0.5">
+            Remove →{" "}
+            <span className="inline-block max-w-[180px] truncate align-bottom">
+              {proposal.to}
+            </span>
+          </p>
+        </>
+      );
+    case "change_threshold":
+      return (
+        <>
+          <Link
+            to={`/proposals/${proposal.id}`}
+            className="font-semibold text-white transition-colors hover:text-emerald-300 focus:outline-none focus:ring-2 focus:ring-zinc-400 rounded"
+          >
+            Change Threshold
+          </Link>
+          <p className="text-zinc-500 text-sm font-mono mt-0.5">
+            Require → {proposal.to}
+          </p>
+        </>
+      );
+    case "set_spending_limit":
+      return (
+        <>
+          <Link
+            to={`/proposals/${proposal.id}`}
+            className="font-semibold text-white transition-colors hover:text-emerald-300 focus:outline-none focus:ring-2 focus:ring-zinc-400 rounded"
+          >
+            Set Spending Limit
+          </Link>
+          <p className="text-zinc-500 text-sm font-mono mt-0.5">
+            Owner →{" "}
+            <span className="inline-block max-w-[180px] truncate align-bottom">
+              {proposal.to}
+            </span>
+            , Limit → {proposal.amount} {proposal.token}
+          </p>
+        </>
+      );
+  }
+}
 
 export function ProposalCard({
   proposal,
@@ -70,22 +168,15 @@ export function ProposalCard({
     <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4 hover:border-zinc-700 transition-colors">
       <div className="flex items-start justify-between mb-4 gap-2">
         <div className="min-w-0 flex-1">
-          <p className="text-xs text-zinc-500 font-mono mb-1">
-            Proposal #{proposal.id}
-          </p>
-          <Link
-            to={`/proposals/${proposal.id}`}
-            className="font-semibold text-white transition-colors hover:text-emerald-300 focus:outline-none focus:ring-2 focus:ring-zinc-400 rounded"
-          >
-            Send {proposal.amount} {proposal.token}
-          </Link>
-          <p className="text-zinc-500 text-sm font-mono mt-0.5">
-            →{" "}
-            <span className="inline-block max-w-[180px] truncate align-bottom">
-              {proposal.to}
+          <div className="flex items-center gap-2 mb-1">
+            <p className="text-xs text-zinc-500 font-mono">
+              Proposal #{proposal.id}
+            </p>
+            <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-zinc-800 text-zinc-400 font-mono">
+              {KIND_LABELS[proposal.kind].badge}
             </span>
-          </p>
-          {/* The proposer's address */}
+          </div>
+          <KindSummary proposal={proposal} />
           <div className="flex items-center gap-2 mt-0.5">
             <p className="text-zinc-500 text-sm font-mono">
               Proposed by → {proposal.proposer.slice(0, 6)}...

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -148,6 +148,19 @@ export async function getThreshold(): Promise<number> {
   return Number(scValToNative(val));
 }
 
+export async function getSpendingLimit(owner: string, token: string): Promise<bigint> {
+  try {
+    const val = await simulateView("get_spending_limit", [
+      nativeToScVal(owner, { type: "address" }),
+      nativeToScVal(token, { type: "address" }),
+    ]);
+    const raw = scValToNative(val);
+    return safeBigInt(raw);
+  } catch {
+    return -1n; // No limit record exists
+  }
+}
+
 export async function getTotalProposals(): Promise<number> {
   const val = await simulateView("get_total_proposals");
   return Number(scValToNative(val));

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -6,7 +6,7 @@ import {
   scValToNative,
   xdr,
 } from "@stellar/stellar-sdk";
-import type { Proposal, ProposalStatus } from "../types/accord";
+import type { Proposal, ProposalKind, ProposalStatus } from "../types/accord";
 import { stroopsToDisplay, formatDeadline, shortenAddr } from "./soroban";
 
 const RPC_URL = import.meta.env.VITE_SOROBAN_RPC_URL as string;
@@ -64,13 +64,9 @@ function safeBigInt(value: unknown): bigint {
   }
 }
 
-function mapKindDetails(kind: unknown): Pick<Proposal, "to" | "amount" | "token"> {
+function mapKind(kind: unknown): { kind: ProposalKind; to: string; amount: string; token: string } {
   if (!kind || typeof kind !== "object") {
-    return {
-      to: "Unknown",
-      amount: "0",
-      token: "Unknown",
-    };
+    return { kind: "transfer", to: "Unknown", amount: "0", token: "Unknown" };
   }
 
   const [variant, payload] = Object.entries(kind as Record<string, unknown>)[0] ?? [];
@@ -80,47 +76,55 @@ function mapKindDetails(kind: unknown): Pick<Proposal, "to" | "amount" | "token"
   switch (normalizedVariant) {
     case "transfer":
       return {
+        kind: "transfer",
         to: shortenAddr(String(values[0] ?? "Unknown")),
         amount: stroopsToDisplay(safeBigInt(values[1])),
         token: shortenAddr(String(values[2] ?? "Unknown")),
       };
     case "addowner":
       return {
+        kind: "add_owner",
         to: shortenAddr(String(values[0] ?? "Unknown")),
         amount: "—",
         token: "Add owner",
       };
     case "removeowner":
       return {
+        kind: "remove_owner",
         to: shortenAddr(String(values[0] ?? "Unknown")),
         amount: "—",
         token: "Remove owner",
       };
     case "changethreshold":
       return {
+        kind: "change_threshold",
         to: `${values[0] ?? "Unknown"} approvals`,
         amount: "—",
         token: "Threshold",
       };
-    default:
+    case "setspendinglimit":
       return {
-        to: "Unknown",
-        amount: "0",
-        token: "Unknown",
+        kind: "set_spending_limit",
+        to: shortenAddr(String(values[0] ?? "Unknown")),
+        amount: stroopsToDisplay(safeBigInt(values[1])),
+        token: shortenAddr(String(values[2] ?? "Unknown")),
       };
+    default:
+      return { kind: "transfer", to: "Unknown", amount: "0", token: "Unknown" };
   }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function mapProposal(raw: any, threshold: number): Proposal {
   const rawDeadline = BigInt(raw.deadline);
-  const details = mapKindDetails(raw.kind);
+  const mapped = mapKind(raw.kind);
 
   return {
     id: Number(raw.id),
-    to: details.to,
-    amount: details.amount,
-    token: details.token,
+    kind: mapped.kind,
+    to: mapped.to,
+    amount: mapped.amount,
+    token: mapped.token,
     description: String(raw.description),
     approvals: Number(raw.approvals),
     threshold,

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -274,6 +274,26 @@ export async function getContractUsdcBalance(): Promise<string> {
   }
 }
 
+export async function getGuardian(): Promise<string> {
+  try {
+    const val = await simulateView("get_guardian");
+    const raw = scValToNative(val);
+    return String(raw);
+  } catch {
+    return "Unknown";
+  }
+}
+
+export async function isFrozen(): Promise<boolean> {
+  try {
+    const val = await simulateView("is_frozen");
+    const raw = scValToNative(val);
+    return Boolean(raw);
+  } catch {
+    return false;
+  }
+}
+
 export async function getApprovers(proposalId: number): Promise<string[]> {
   try {
     const owners = await getOwners();

--- a/frontend/src/lib/submit.ts
+++ b/frontend/src/lib/submit.ts
@@ -147,6 +147,24 @@ export async function createProposal(
   ]);
 }
 
+export async function createSpendingLimitProposal(
+  callerAddress: string,
+  owner: string,
+  tokenAddress: string,
+  amount: bigint,
+  description: string,
+  deadlineTs: bigint
+): Promise<void> {
+  await buildAndSubmit(callerAddress, "create_set_spending_limit_proposal", [
+    nativeToScVal(callerAddress, { type: "address" }),
+    nativeToScVal(owner, { type: "address" }),
+    nativeToScVal(tokenAddress, { type: "address" }),
+    nativeToScVal(amount, { type: "i128" }),
+    xdr.ScVal.scvString(description),
+    nativeToScVal(deadlineTs, { type: "u64" }),
+  ]);
+}
+
 export async function estimateCreateProposalFee(
   callerAddress: string,
   to: string,

--- a/frontend/src/lib/submit.ts
+++ b/frontend/src/lib/submit.ts
@@ -165,6 +165,98 @@ export async function createSpendingLimitProposal(
   ]);
 }
 
+// ─── Guardian / emergency pause ─────────────────────────────────────────────
+
+export async function freeze(
+  callerAddress: string
+): Promise<void> {
+  await buildAndSubmit(callerAddress, "freeze", [
+    nativeToScVal(callerAddress, { type: "address" }),
+  ]);
+}
+
+export async function createSetGuardianProposal(
+  callerAddress: string,
+  newGuardian: string,
+  description: string,
+  deadlineTs: bigint
+): Promise<void> {
+  await buildAndSubmit(callerAddress, "create_set_guardian_proposal", [
+    nativeToScVal(callerAddress, { type: "address" }),
+    nativeToScVal(newGuardian, { type: "address" }),
+    xdr.ScVal.scvString(description),
+    nativeToScVal(deadlineTs, { type: "u64" }),
+  ]);
+}
+
+export async function createUnfreezeProposal(
+  callerAddress: string,
+  description: string,
+  deadlineTs: bigint
+): Promise<void> {
+  await buildAndSubmit(callerAddress, "create_unfreeze_proposal", [
+    nativeToScVal(callerAddress, { type: "address" }),
+    xdr.ScVal.scvString(description),
+    nativeToScVal(deadlineTs, { type: "u64" }),
+  ]);
+}
+
+// ─── Co-signature helpers ────────────────────────────────────────────────────
+
+export async function buildAndAssembleTx(
+  callerAddress: string,
+  fn: string,
+  args: xdr.ScVal[]
+): Promise<string> {
+  const account = await server.getAccount(callerAddress);
+  const contract = new Contract(CONTRACT_ID);
+
+  const tx = new TransactionBuilder(account, {
+    fee: "100000",
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call(fn, ...args))
+    .setTimeout(30)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+  if (!rpc.Api.isSimulationSuccess(sim)) {
+    const err = sim as rpc.Api.SimulateTransactionErrorResponse;
+    throw new Error(`Simulation failed: ${err.error ?? "unknown"}`);
+  }
+
+  const assembled = rpc.assembleTransaction(tx, sim).build();
+  return assembled.toXDR();
+}
+
+export async function signAndSubmitMultiSig(
+  xdrStr: string,
+  networkPassphrase?: string
+): Promise<void> {
+  const passphrase = networkPassphrase ?? NETWORK_PASSPHRASE;
+  const signed = await signTx(xdrStr, passphrase.includes("Public") ? "PUBLIC" : "TESTNET");
+  if (!signed.ok) throw new Error(signed.error);
+
+  const tx = TransactionBuilder.fromXDR(signed.value, passphrase);
+  const sent = await server.sendTransaction(tx);
+
+  if (sent.status === "ERROR") {
+    throw new Error(`Submit failed: ${JSON.stringify(sent.errorResult)}`);
+  }
+
+  const hash = sent.hash;
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 2000));
+    const res = await server.getTransaction(hash);
+    if (res.status === "SUCCESS") return;
+    if (res.status === "FAILED") {
+      throw new Error(`Transaction failed on-chain`);
+    }
+  }
+  throw new Error("Transaction not confirmed within 60s");
+}
+
 export async function estimateCreateProposalFee(
   callerAddress: string,
   to: string,

--- a/frontend/src/lib/submit.ts
+++ b/frontend/src/lib/submit.ts
@@ -164,3 +164,47 @@ export async function estimateCreateProposalFee(
     nativeToScVal(deadlineTs, { type: "u64" }),
   ]);
 }
+
+// ─── Governance proposal creation ────────────────────────────────────────────
+
+export async function createAddOwnerProposal(
+  callerAddress: string,
+  newOwner: string,
+  description: string,
+  deadlineTs: bigint
+): Promise<void> {
+  await buildAndSubmit(callerAddress, "create_add_owner_proposal", [
+    nativeToScVal(callerAddress, { type: "address" }),
+    nativeToScVal(newOwner, { type: "address" }),
+    xdr.ScVal.scvString(description),
+    nativeToScVal(deadlineTs, { type: "u64" }),
+  ]);
+}
+
+export async function createRemoveOwnerProposal(
+  callerAddress: string,
+  ownerToRemove: string,
+  description: string,
+  deadlineTs: bigint
+): Promise<void> {
+  await buildAndSubmit(callerAddress, "create_remove_owner_proposal", [
+    nativeToScVal(callerAddress, { type: "address" }),
+    nativeToScVal(ownerToRemove, { type: "address" }),
+    xdr.ScVal.scvString(description),
+    nativeToScVal(deadlineTs, { type: "u64" }),
+  ]);
+}
+
+export async function createChangeThresholdProposal(
+  callerAddress: string,
+  newThreshold: number,
+  description: string,
+  deadlineTs: bigint
+): Promise<void> {
+  await buildAndSubmit(callerAddress, "create_change_threshold_proposal", [
+    nativeToScVal(callerAddress, { type: "address" }),
+    nativeToScVal(newThreshold, { type: "u32" }),
+    xdr.ScVal.scvString(description),
+    nativeToScVal(deadlineTs, { type: "u64" }),
+  ]);
+}

--- a/frontend/src/pages/OwnersPage.tsx
+++ b/frontend/src/pages/OwnersPage.tsx
@@ -1,16 +1,144 @@
+import { useEffect, useState } from "react";
+import { getSpendingLimit } from "../lib/contract";
+import { createSpendingLimitProposal } from "../lib/submit";
+import { displayToStroops, stroopsToDisplay } from "../lib/soroban";
+import { StrKey } from "@stellar/stellar-sdk";
 import type { Owner } from "../types/accord";
+
+const TOKEN_ADDRESSES: Record<string, string> = {
+  XLM: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+  USDC: "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA",
+  EURC: "GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4IQDNC",
+};
+
+const TOKEN_SYMBOLS = ["XLM", "USDC", "EURC"] as const;
+
+type SpendingLimitMap = Record<string, Record<string, bigint>>;
 
 type OwnersPageProps = {
   owners: Owner[];
+  ownerAddresses: string[];
   threshold: number;
   totalOwners: number;
+  walletAddress: string | null;
+  onProposalSubmitted: () => void;
 };
 
 export function OwnersPage({
   owners,
+  ownerAddresses,
   threshold,
   totalOwners,
+  walletAddress,
+  onProposalSubmitted,
 }: OwnersPageProps) {
+  const [spendingLimits, setSpendingLimits] = useState<SpendingLimitMap>({});
+  const [limitsLoading, setLimitsLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+
+  // Spending limit proposal form state
+  const [slOwner, setSlOwner] = useState("");
+  const [slToken, setSlToken] = useState("XLM");
+  const [slAmount, setSlAmount] = useState("");
+  const [slDescription, setSlDescription] = useState("");
+  const [slDeadline, setSlDeadline] = useState(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 7);
+    return d.toISOString().slice(0, 10);
+  });
+  const [slSubmitting, setSlSubmitting] = useState(false);
+  const [slError, setSlError] = useState<string | null>(null);
+
+  // Load spending limits for all owners and tokens
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLimitsLoading(true);
+      const map: SpendingLimitMap = {};
+      for (const addr of ownerAddresses) {
+        map[addr] = {};
+        for (const symbol of TOKEN_SYMBOLS) {
+          const tokenAddr = TOKEN_ADDRESSES[symbol];
+          const limit = await getSpendingLimit(addr, tokenAddr);
+          if (!cancelled) {
+            map[addr][symbol] = limit;
+          }
+        }
+      }
+      if (!cancelled) {
+        setSpendingLimits(map);
+        setLimitsLoading(false);
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [ownerAddresses]);
+
+  function formatLimit(limit: bigint, symbol: string): { text: string; variant: "unrestricted" | "zero" | "configured" } {
+    if (limit < 0n) return { text: "Unrestricted", variant: "unrestricted" };
+    if (limit === 0n) return { text: `0 ${symbol}`, variant: "zero" };
+    return { text: `${stroopsToDisplay(limit)} ${symbol}`, variant: "configured" };
+  }
+
+  async function handleCreateSpendingLimit() {
+    if (!walletAddress) {
+      setSlError("Connect your wallet first.");
+      return;
+    }
+    if (!slOwner.trim() || !slAmount.trim() || !slDescription.trim()) {
+      setSlError("Owner, amount, and description are required.");
+      return;
+    }
+    if (!StrKey.isValidEd25519PublicKey(slOwner.trim())) {
+      setSlError("Enter a valid Stellar address for the owner.");
+      return;
+    }
+    const tokenAddr = TOKEN_ADDRESSES[slToken];
+    if (!tokenAddr) {
+      setSlError("Unknown token.");
+      return;
+    }
+    const amountNum = parseFloat(slAmount);
+    if (isNaN(amountNum) || amountNum < 0) {
+      setSlError("Enter a valid amount (0 to block spending).");
+      return;
+    }
+    const deadlineMs = new Date(slDeadline).getTime();
+    const nowMs = Date.now();
+    const todayMidnight = new Date();
+    todayMidnight.setHours(0, 0, 0, 0);
+    if (deadlineMs <= todayMidnight.getTime()) {
+      setSlError("Deadline must be in the future.");
+      return;
+    }
+    const maxMs = nowMs + 90 * 24 * 3600 * 1000;
+    if (deadlineMs > maxMs) {
+      setSlError("Deadline cannot be more than 90 days away.");
+      return;
+    }
+
+    setSlSubmitting(true);
+    setSlError(null);
+    try {
+      await createSpendingLimitProposal(
+        walletAddress,
+        slOwner.trim(),
+        tokenAddr,
+        displayToStroops(amountNum),
+        slDescription.trim(),
+        BigInt(Math.floor(deadlineMs / 1000))
+      );
+      onProposalSubmitted();
+      setShowForm(false);
+      setSlAmount("");
+      setSlDescription("");
+    } catch (e) {
+      setSlError(e instanceof Error ? e.message : "Transaction failed");
+    } finally {
+      setSlSubmitting(false);
+    }
+  }
+
   return (
     <>
       <div className="mb-8">
@@ -20,28 +148,176 @@ export function OwnersPage({
         </p>
       </div>
 
+      {/* Owners list with spending limits */}
       {owners.length === 0 ? (
         <div className="text-center py-12">
           <p className="text-zinc-600 text-sm">No owners found.</p>
         </div>
       ) : (
-        <div className="bg-zinc-900 border border-zinc-800 rounded-xl divide-y divide-zinc-800">
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl divide-y divide-zinc-800 mb-8">
           {owners.map((owner) => (
-            <div
-              key={owner.address}
-              className="flex items-center gap-3 px-4 py-4"
-            >
-              <div className="w-7 h-7 rounded-full bg-zinc-700 flex items-center justify-center text-xs text-zinc-400">
-                {owner.label[0]}
+            <div key={owner.address}>
+              <div className="flex items-center gap-3 px-4 py-4">
+                <div className="w-7 h-7 rounded-full bg-zinc-700 flex items-center justify-center text-xs text-zinc-400">
+                  {owner.label[0]}
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm text-zinc-300">{owner.label}</p>
+                  <p className="font-mono text-xs text-zinc-500">{owner.address}</p>
+                </div>
               </div>
-              <div>
-                <p className="text-sm text-zinc-300">{owner.label}</p>
-                <p className="font-mono text-xs text-zinc-500">{owner.address}</p>
-              </div>
+
+              {/* Spending limits per token */}
+              {limitsLoading ? (
+                <div className="px-4 pb-4">
+                  <div className="h-4 w-32 bg-zinc-800 animate-pulse rounded" />
+                </div>
+              ) : (
+                <div className="px-4 pb-4 pl-14 grid grid-cols-3 gap-2">
+                  {TOKEN_SYMBOLS.map((symbol) => {
+                    const rawAddr = ownerAddresses[
+                      owners.findIndex((o) => o.address === owner.address)
+                    ];
+                    const limit = rawAddr ? spendingLimits[rawAddr]?.[symbol] : undefined;
+                    const info = limit !== undefined
+                      ? formatLimit(limit, symbol)
+                      : { text: "—", variant: "unrestricted" as const };
+
+                    const variantStyles = {
+                      unrestricted: "text-zinc-500",
+                      zero: "text-red-400",
+                      configured: "text-emerald-400",
+                    };
+
+                    return (
+                      <div key={symbol} className="text-xs">
+                        <span className="text-zinc-600">{symbol}: </span>
+                        <span className={`font-mono ${variantStyles[info.variant]}`}>
+                          {info.text}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           ))}
         </div>
       )}
+
+      {/* Spending limit proposal form */}
+      <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-5">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold">Spending Limits</h2>
+          <button
+            type="button"
+            onClick={() => setShowForm(!showForm)}
+            className="text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-300 px-3 py-1.5 rounded-lg transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+          >
+            {showForm ? "Cancel" : "Set Spending Limit"}
+          </button>
+        </div>
+
+        {showForm && (
+          <div className="space-y-4 border-t border-zinc-800 pt-4">
+            <p className="text-xs text-zinc-400">
+              Propose a per-owner, per-token spending limit. Set to 0 to block spending for that token.
+            </p>
+
+            <div>
+              <label className="text-xs text-zinc-400 block mb-1.5">Owner Address</label>
+              <input
+                value={slOwner}
+                onChange={(e) => setSlOwner(e.target.value)}
+                placeholder="G..."
+                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm font-mono placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+              />
+            </div>
+
+            <div className="flex gap-3">
+              <div className="flex-1">
+                <label className="text-xs text-zinc-400 block mb-1.5">
+                  Limit Amount
+                </label>
+                <input
+                  value={slAmount}
+                  onChange={(e) => setSlAmount(e.target.value)}
+                  placeholder="0.00"
+                  type="number"
+                  min="0"
+                  step="any"
+                  className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+                />
+              </div>
+              <div className="w-28">
+                <label className="text-xs text-zinc-400 block mb-1.5">Token</label>
+                <div className="grid grid-cols-3 gap-1">
+                  {TOKEN_SYMBOLS.map((symbol) => {
+                    const active = slToken === symbol;
+                    return (
+                      <button
+                        key={symbol}
+                        type="button"
+                        onClick={() => setSlToken(symbol)}
+                        aria-pressed={active}
+                        className={`rounded-lg border px-1.5 py-2 text-xs font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none ${
+                          active
+                            ? "border-emerald-500 bg-emerald-500/20 text-emerald-300"
+                            : "border-zinc-700 bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
+                        }`}
+                      >
+                        {symbol}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <label className="text-xs text-zinc-400 block mb-1.5">Description</label>
+              <input
+                value={slDescription}
+                onChange={(e) => setSlDescription(e.target.value)}
+                placeholder="Reason for spending limit"
+                maxLength={300}
+                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+              />
+            </div>
+
+            <div>
+              <label className="text-xs text-zinc-400 block mb-1.5">Deadline</label>
+              <input
+                type="date"
+                value={slDeadline}
+                onChange={(e) => setSlDeadline(e.target.value)}
+                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+              />
+            </div>
+
+            {slError && (
+              <p className="text-xs text-red-400 bg-red-500/10 rounded-lg px-3 py-2">
+                {slError}
+              </p>
+            )}
+
+            <button
+              type="button"
+              onClick={handleCreateSpendingLimit}
+              disabled={slSubmitting || !walletAddress}
+              className="w-full bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white py-2.5 rounded-lg font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+            >
+              {slSubmitting ? "Submitting…" : "Create Spending Limit Proposal"}
+            </button>
+          </div>
+        )}
+
+        {!showForm && (
+          <p className="text-xs text-zinc-500">
+            Configure per-owner spending limits for specific tokens. All changes require multisig approval.
+          </p>
+        )}
+      </div>
     </>
   );
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,12 +1,28 @@
 import { useEffect, useState } from "react";
-import { getContractXlmBalance, getContractUsdcBalance } from "../lib/contract";
+import {
+  getContractXlmBalance,
+  getContractUsdcBalance,
+  getGuardian,
+  isFrozen,
+} from "../lib/contract";
+import {
+  freeze,
+  createSetGuardianProposal,
+  createUnfreezeProposal,
+} from "../lib/submit";
+import { StrKey } from "@stellar/stellar-sdk";
 import type { DashboardStat } from "../types/accord";
+
+const MAX_DESCRIPTION_LEN = 300;
 
 type SettingsPageProps = {
   stats: DashboardStat[];
+  walletAddress: string | null;
+  ownerAddresses: string[];
+  onProposalSubmitted: () => void;
 };
 
-export function SettingsPage({ stats }: SettingsPageProps) {
+export function SettingsPage({ stats, walletAddress, ownerAddresses, onProposalSubmitted }: SettingsPageProps) {
   const contractId = import.meta.env.VITE_CONTRACT_ADDRESS ?? "Unknown";
   const network = import.meta.env.VITE_NETWORK_PASSPHRASE ?? "Unknown";
   const threshold = stats.find((stat) => stat.label === "Threshold")?.value ?? "Unknown";
@@ -16,18 +32,59 @@ export function SettingsPage({ stats }: SettingsPageProps) {
   const [balanceLoading, setBalanceLoading] = useState(true);
   const [copied, setCopied] = useState(false);
 
+  // Guardian / Freeze state
+  const [guardian, setGuardian] = useState<string>("—");
+  const [frozen, setFrozen] = useState(false);
+  const [guardianLoading, setGuardianLoading] = useState(true);
+
+  // Freeze control
+  const [showFreezeConfirm, setShowFreezeConfirm] = useState(false);
+  const [freezing, setFreezing] = useState(false);
+  const [freezeError, setFreezeError] = useState<string | null>(null);
+
+  // Set Guardian proposal form
+  const [showSetGuardian, setShowSetGuardian] = useState(false);
+  const [sgNewGuardian, setSgNewGuardian] = useState("");
+  const [sgDescription, setSgDescription] = useState("");
+  const [sgDeadline, setSgDeadline] = useState(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 7);
+    return d.toISOString().slice(0, 10);
+  });
+  const [sgSubmitting, setSgSubmitting] = useState(false);
+  const [sgError, setSgError] = useState<string | null>(null);
+
+  // Unfreeze proposal form
+  const [showUnfreeze, setShowUnfreeze] = useState(false);
+  const [ufDescription, setUfDescription] = useState("");
+  const [ufDeadline, setUfDeadline] = useState(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 7);
+    return d.toISOString().slice(0, 10);
+  });
+  const [ufSubmitting, setUfSubmitting] = useState(false);
+  const [ufError, setUfError] = useState<string | null>(null);
+
+  const isOwner = walletAddress && ownerAddresses.includes(walletAddress);
+  const isGuardian = walletAddress && guardian === walletAddress;
+
   useEffect(() => {
     let cancelled = false;
     async function load() {
       setBalanceLoading(true);
-      const [xlm, usdc] = await Promise.all([
+      const [xlm, usdc, g, f] = await Promise.all([
         getContractXlmBalance().catch(() => "—"),
         getContractUsdcBalance().catch(() => "—"),
+        getGuardian().catch(() => "—"),
+        isFrozen().catch(() => false),
       ]);
       if (!cancelled) {
         setXlmBalance(xlm);
         setUsdcBalance(usdc);
+        setGuardian(g);
+        setFrozen(f);
         setBalanceLoading(false);
+        setGuardianLoading(false);
       }
     }
     load();
@@ -41,6 +98,104 @@ export function SettingsPage({ stats }: SettingsPageProps) {
       setTimeout(() => setCopied(false), 1500);
     } catch {
       // Clipboard API not available
+    }
+  }
+
+  // ─── Freeze (single-sig, guardian only) ──────────────────────────────────
+
+  async function handleFreeze() {
+    if (!walletAddress || !isGuardian) return;
+    setFreezing(true);
+    setFreezeError(null);
+    try {
+      await freeze(walletAddress);
+      setFrozen(true);
+      setShowFreezeConfirm(false);
+      onProposalSubmitted();
+    } catch (e) {
+      setFreezeError(e instanceof Error ? e.message : "Freeze failed");
+    } finally {
+      setFreezing(false);
+    }
+  }
+
+  // ─── Set Guardian proposal ───────────────────────────────────────────────
+
+  async function handleSetGuardian() {
+    if (!walletAddress || !isOwner) {
+      setSgError("Only owners can submit this proposal.");
+      return;
+    }
+    if (!sgNewGuardian.trim() || !sgDescription.trim()) {
+      setSgError("Guardian address and description are required.");
+      return;
+    }
+    if (!StrKey.isValidEd25519PublicKey(sgNewGuardian.trim())) {
+      setSgError("Enter a valid Stellar address.");
+      return;
+    }
+    const deadlineMs = new Date(sgDeadline).getTime();
+    const todayMidnight = new Date();
+    todayMidnight.setHours(0, 0, 0, 0);
+    if (deadlineMs <= todayMidnight.getTime()) {
+      setSgError("Deadline must be in the future.");
+      return;
+    }
+
+    setSgSubmitting(true);
+    setSgError(null);
+    try {
+      await createSetGuardianProposal(
+        walletAddress,
+        sgNewGuardian.trim(),
+        sgDescription.trim(),
+        BigInt(Math.floor(deadlineMs / 1000))
+      );
+      onProposalSubmitted();
+      setShowSetGuardian(false);
+      setSgNewGuardian("");
+      setSgDescription("");
+    } catch (e) {
+      setSgError(e instanceof Error ? e.message : "Transaction failed");
+    } finally {
+      setSgSubmitting(false);
+    }
+  }
+
+  // ─── Unfreeze proposal ───────────────────────────────────────────────────
+
+  async function handleUnfreeze() {
+    if (!walletAddress || !isOwner) {
+      setUfError("Only owners can submit this proposal.");
+      return;
+    }
+    if (!ufDescription.trim()) {
+      setUfError("Description is required.");
+      return;
+    }
+    const deadlineMs = new Date(ufDeadline).getTime();
+    const todayMidnight = new Date();
+    todayMidnight.setHours(0, 0, 0, 0);
+    if (deadlineMs <= todayMidnight.getTime()) {
+      setUfError("Deadline must be in the future.");
+      return;
+    }
+
+    setUfSubmitting(true);
+    setUfError(null);
+    try {
+      await createUnfreezeProposal(
+        walletAddress,
+        ufDescription.trim(),
+        BigInt(Math.floor(deadlineMs / 1000))
+      );
+      onProposalSubmitted();
+      setShowUnfreeze(false);
+      setUfDescription("");
+    } catch (e) {
+      setUfError(e instanceof Error ? e.message : "Transaction failed");
+    } finally {
+      setUfSubmitting(false);
     }
   }
 
@@ -79,6 +234,210 @@ export function SettingsPage({ stats }: SettingsPageProps) {
         </div>
       </div>
 
+      {/* Guardian & Freeze Status */}
+      <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-5">
+        <h2 className="text-lg font-semibold mb-4">Guardian & Emergency Controls</h2>
+
+        {guardianLoading ? (
+          <div className="space-y-3">
+            <div className="h-5 w-48 bg-zinc-800 animate-pulse rounded" />
+            <div className="h-5 w-32 bg-zinc-800 animate-pulse rounded" />
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-zinc-500 mb-1">Current Guardian</p>
+                <p className="font-mono text-sm text-zinc-200">
+                  {guardian === "—" ? "—" : `${guardian.slice(0, 6)}...${guardian.slice(-4)}`}
+                </p>
+              </div>
+              <div className="text-right">
+                <p className="text-xs text-zinc-500 mb-1">Contract Status</p>
+                <span
+                  className={`text-xs px-2 py-0.5 rounded-full font-mono ${
+                    frozen
+                      ? "bg-red-500/10 text-red-400 border border-red-500/20"
+                      : "bg-emerald-500/10 text-emerald-400 border border-emerald-500/20"
+                  }`}
+                >
+                  {frozen ? "Frozen" : "Active"}
+                </span>
+              </div>
+            </div>
+
+            {/* Freeze button — guardian only */}
+            {!frozen && isGuardian && (
+              <div className="pt-2">
+                {!showFreezeConfirm ? (
+                  <button
+                    type="button"
+                    onClick={() => setShowFreezeConfirm(true)}
+                    className="bg-red-600 hover:bg-red-500 text-white text-sm px-4 py-2 rounded-lg font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+                  >
+                    Freeze Contract
+                  </button>
+                ) : (
+                  <div className="space-y-3 rounded-xl border border-red-500/20 bg-red-500/10 p-4">
+                    <p className="text-sm text-red-300 font-medium">
+                      Warning: Freezing will halt all proposal creation and execution until unfrozen.
+                    </p>
+                    <div className="flex gap-3">
+                      <button
+                        type="button"
+                        onClick={handleFreeze}
+                        disabled={freezing}
+                        className="bg-red-600 hover:bg-red-500 disabled:opacity-50 text-white text-sm px-4 py-2 rounded-lg font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+                      >
+                        {freezing ? "Freezing…" : "Confirm Freeze"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setShowFreezeConfirm(false)}
+                        disabled={freezing}
+                        className="bg-zinc-700 hover:bg-zinc-600 disabled:opacity-50 text-white text-sm px-4 py-2 rounded-lg font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                    {freezeError && (
+                      <p className="text-xs text-red-400">{freezeError}</p>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Set Guardian — proposal flow */}
+      {isOwner && (
+        <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-5">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold">Set Guardian</h2>
+            <button
+              type="button"
+              onClick={() => setShowSetGuardian(!showSetGuardian)}
+              className="text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-300 px-3 py-1.5 rounded-lg transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+            >
+              {showSetGuardian ? "Cancel" : "Propose Change"}
+            </button>
+          </div>
+
+          {showSetGuardian && (
+            <div className="space-y-4 border-t border-zinc-800 pt-4">
+              <p className="text-xs text-zinc-400">
+                Propose a new guardian address. This requires multisig approval.
+              </p>
+
+              <div>
+                <label className="text-xs text-zinc-400 block mb-1.5">New Guardian Address</label>
+                <input
+                  value={sgNewGuardian}
+                  onChange={(e) => setSgNewGuardian(e.target.value)}
+                  placeholder="G..."
+                  className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm font-mono placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+                />
+              </div>
+
+              <div>
+                <label className="text-xs text-zinc-400 block mb-1.5">Description</label>
+                <input
+                  value={sgDescription}
+                  onChange={(e) => setSgDescription(e.target.value)}
+                  placeholder="Reason for guardian change"
+                  maxLength={MAX_DESCRIPTION_LEN}
+                  className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+                />
+              </div>
+
+              <div>
+                <label className="text-xs text-zinc-400 block mb-1.5">Deadline</label>
+                <input
+                  type="date"
+                  value={sgDeadline}
+                  onChange={(e) => setSgDeadline(e.target.value)}
+                  className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+                />
+              </div>
+
+              {sgError && (
+                <p className="text-xs text-red-400 bg-red-500/10 rounded-lg px-3 py-2">{sgError}</p>
+              )}
+
+              <button
+                type="button"
+                onClick={handleSetGuardian}
+                disabled={sgSubmitting}
+                className="w-full bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white py-2.5 rounded-lg font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+              >
+                {sgSubmitting ? "Submitting…" : "Create Set Guardian Proposal"}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Unfreeze — proposal flow */}
+      {frozen && isOwner && (
+        <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-5">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold">Unfreeze Contract</h2>
+            <button
+              type="button"
+              onClick={() => setShowUnfreeze(!showUnfreeze)}
+              className="text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-300 px-3 py-1.5 rounded-lg transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+            >
+              {showUnfreeze ? "Cancel" : "Propose Unfreeze"}
+            </button>
+          </div>
+
+          {showUnfreeze && (
+            <div className="space-y-4 border-t border-zinc-800 pt-4">
+              <p className="text-xs text-zinc-400">
+                Propose to unfreeze the contract. This requires multisig approval.
+              </p>
+
+              <div>
+                <label className="text-xs text-zinc-400 block mb-1.5">Description</label>
+                <input
+                  value={ufDescription}
+                  onChange={(e) => setUfDescription(e.target.value)}
+                  placeholder="Reason for unfreezing"
+                  maxLength={MAX_DESCRIPTION_LEN}
+                  className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+                />
+              </div>
+
+              <div>
+                <label className="text-xs text-zinc-400 block mb-1.5">Deadline</label>
+                <input
+                  type="date"
+                  value={ufDeadline}
+                  onChange={(e) => setUfDeadline(e.target.value)}
+                  className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
+                />
+              </div>
+
+              {ufError && (
+                <p className="text-xs text-red-400 bg-red-500/10 rounded-lg px-3 py-2">{ufError}</p>
+              )}
+
+              <button
+                type="button"
+                onClick={handleUnfreeze}
+                disabled={ufSubmitting}
+                className="w-full bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white py-2.5 rounded-lg font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+              >
+                {ufSubmitting ? "Submitting…" : "Create Unfreeze Proposal"}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Fund Contract */}
       <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-5">
         <h2 className="text-lg font-semibold mb-4">Fund Contract</h2>
         <p className="text-sm text-zinc-400 mb-4">

--- a/frontend/src/types/accord.ts
+++ b/frontend/src/types/accord.ts
@@ -1,7 +1,10 @@
 export type ProposalStatus = "pending" | "ready" | "executed" | "expired" | "revoked";
 
+export type ProposalKind = "transfer" | "add_owner" | "remove_owner" | "change_threshold" | "set_spending_limit";
+
 export type Proposal = {
   id: number;
+  kind: ProposalKind;
   to: string;
   amount: string;
   token: string;


### PR DESCRIPTION
All 4 tasks complete. TypeScript compiles cleanly and all 61 tests pass (10 test files). Here's a summary of the implementation:

Closes #242 - feat(frontend): add proposal kind/category types and multi-kind ProposalCard rendering

Added ProposalKind union type to types/accord.ts
Extended Proposal interface with kind field
Refactored mapKindDetails → mapKind in contract.ts to return kind discriminant; added SetSpendingLimit variant support
Refactored ProposalCard with KindSummary component that branches on proposal.kind with clear summary views for each kind

Closes #243 - feat(frontend): implement creation flows for governance proposals

Added createAddOwnerProposal, createRemoveOwnerProposal, createChangeThresholdProposal to submit.ts
Refactored CreateProposalModal with proposal type selector (Transfer/AddOwner/RemoveOwner/ChangeThreshold)
Each governance type has specific validated form fields and plain-English preview
Added proper discriminated union types for form data

Closes #244 - feat(frontend): add spending limit display table and proposal creation UI

Added getSpendingLimit(owner, token) to contract.ts
Added createSpendingLimitProposal to submit.ts
Expanded OwnersPage with per-owner per-token limit display (Unrestricted/Zero/Configured) and inline proposal form

Closes #245 - feat(frontend): add guardian status, emergency pause, co-sig flows, and frozen state banner

Added getGuardian(), isFrozen() to contract.ts
Added freeze(), createSetGuardianProposal(), createUnfreezeProposal() to submit.ts
Added co-signature helpers (buildAndAssembleTx, signAndSubmitMultiSig)
Expanded SettingsPage with guardian display, freeze button (guardian-only), set guardian proposal form, unfreeze proposal form
Added prominent frozen state banner in App.tsx