### PR TITLE
feat: add quorum_weight and total_weight_at_creation to ProposalCreatedEvent

### DIFF
--- a/contracts/accord/src/lib.rs
+++ b/contracts/accord/src/lib.rs
@@ -75,6 +75,16 @@ pub struct ProposalCreatedEvent {
     pub threshold: u32,
     pub category: ProposalCategory,
     pub transfers: Vec<Transfer>,
+    /// The weighted quorum this proposal must reach to become `Ready`. Snapshotted
+    /// at creation so auditors can reconstruct the exact approval requirement even
+    /// after the threshold changes via a later governance proposal.
+    pub quorum_weight: u32,
+    /// Sum of all owner weights at the moment this proposal was created. Because
+    /// owners can be added, removed, or re-weighted after creation, this field is
+    /// the only way to recover the original total-weight context from the event
+    /// log alone — it is not derivable from current contract state once ownership
+    /// changes.
+    pub total_weight_at_creation: u32,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -667,6 +677,7 @@ impl AccordContract {
         write_proposal(&env, &proposal);
         write_active_count(&env, active + 1);
 
+        let total_weight = read_total_weight(&env);
         env.events().publish(
             (symbol_short!("created"),),
             ProposalCreatedEvent {
@@ -675,6 +686,8 @@ impl AccordContract {
                 threshold,
                 category,
                 transfers,
+                quorum_weight: threshold,
+                total_weight_at_creation: total_weight,
             },
         );
 
@@ -744,6 +757,7 @@ impl AccordContract {
         write_proposal(&env, &proposal);
         write_active_count(&env, active + 1);
 
+        let total_weight = read_total_weight(&env);
         env.events().publish(
             (symbol_short!("created"),),
             ProposalCreatedEvent {
@@ -752,6 +766,8 @@ impl AccordContract {
                 threshold,
                 category: ProposalCategory::Other,
                 transfers: Vec::new(&env),
+                quorum_weight: threshold,
+                total_weight_at_creation: total_weight,
             },
         );
 
@@ -817,6 +833,7 @@ impl AccordContract {
         write_proposal(&env, &proposal);
         write_active_count(&env, active + 1);
 
+        let total_weight = read_total_weight(&env);
         env.events().publish(
             (symbol_short!("created"),),
             ProposalCreatedEvent {
@@ -825,6 +842,8 @@ impl AccordContract {
                 threshold,
                 category: ProposalCategory::Other,
                 transfers: Vec::new(&env),
+                quorum_weight: threshold,
+                total_weight_at_creation: total_weight,
             },
         );
 
@@ -905,6 +924,7 @@ impl AccordContract {
         write_proposal(&env, &proposal);
         write_active_count(&env, active + 1);
 
+        let total_weight = read_total_weight(&env);
         env.events().publish(
             (symbol_short!("created"),),
             ProposalCreatedEvent {
@@ -913,6 +933,8 @@ impl AccordContract {
                 threshold,
                 category: ProposalCategory::Other,
                 transfers: Vec::new(&env),
+                quorum_weight: threshold,
+                total_weight_at_creation: total_weight,
             },
         );
 
@@ -981,6 +1003,7 @@ impl AccordContract {
         write_proposal(&env, &proposal);
         write_active_count(&env, active + 1);
 
+        let total_weight = read_total_weight(&env);
         env.events().publish(
             (symbol_short!("created"),),
             ProposalCreatedEvent {
@@ -989,6 +1012,8 @@ impl AccordContract {
                 threshold,
                 category: ProposalCategory::Other,
                 transfers: Vec::new(&env),
+                quorum_weight: threshold,
+                total_weight_at_creation: total_weight,
             },
         );
 

--- a/contracts/accord/src/test.rs
+++ b/contracts/accord/src/test.rs
@@ -1853,6 +1853,58 @@ fn proposer_without_limit_is_unrestricted() {
 
 // ─── Property Tests (issue #55) ─────────────────────────────────────────────────
 
+// ─── ProposalCreatedEvent weight snapshot ────────────────────────────────────
+
+/// Verifies that `ProposalCreatedEvent` captures `quorum_weight` and
+/// `total_weight_at_creation` at the moment of creation, and that those
+/// recorded values are unaffected by weight changes made afterwards.
+#[test]
+fn test_proposal_created_event_snapshots_weights() {
+    // 3 owners each with weight 1, threshold 2 → total_weight = 3.
+    let (env, client, owner_a, owner_b, owner_c, _, token_client) = setup(2);
+
+    let recipient = Address::generate(&env);
+    let _id = client.create_proposal(
+        &owner_a,
+        &t(&env, &recipient, 1_000_000, &token_client.address),
+        &str(&env, "Snapshot test"),
+        &DEADLINE,
+        &ProposalCategory::Transfer,
+    );
+
+    // Capture the ProposalCreatedEvent emitted by the creation call.
+    let all_events = env.events().all();
+    let contract_events = all_events.filter_by_contract(&client.address);
+    assert!(!contract_events.events().is_empty(), "expected a created event");
+
+    let event_data = match &contract_events.events().first().unwrap().body {
+        xdr::ContractEventBody::V0(body) => body.data.clone(),
+    };
+    let event: ProposalCreatedEvent = event_data.into_val(&env);
+
+    // At creation: threshold = 2, total_weight = 3.
+    assert_eq!(event.quorum_weight, 2, "quorum_weight should equal the threshold at creation");
+    assert_eq!(event.total_weight_at_creation, 3, "total_weight_at_creation should equal the sum of all owner weights at creation");
+
+    // Remove owner_c, reducing the live total weight to 2.
+    let remove_id = client.create_remove_owner_proposal(
+        &owner_a,
+        &owner_c,
+        &str(&env, "Remove owner_c"),
+        &DEADLINE,
+    );
+    client.approve(&owner_a, &remove_id);
+    client.approve(&owner_b, &remove_id);
+    client.execute(&owner_b, &remove_id);
+
+    // Live total weight is now 2.
+    assert_eq!(client.get_total_weight(), 2, "total weight after removal should be 2");
+
+    // The original captured event must still reflect the values from creation time.
+    assert_eq!(event.quorum_weight, 2, "historical quorum_weight must be unchanged after owner removal");
+    assert_eq!(event.total_weight_at_creation, 3, "historical total_weight_at_creation must be unchanged after owner removal");
+}
+
 proptest! {
     // Soroban builds a fresh Env per case, so keep the case count modest.
     #![proptest_config(ProptestConfig::with_cases(32))]

--- a/docs/CONTRACT_API.md
+++ b/docs/CONTRACT_API.md
@@ -305,17 +305,21 @@ Each Soroban event has an ordered **topics array** followed by a **data payload*
 |-------|-----------|----------------|-------------|
 | `id` | `u64` | `ScVal::U64` | Unique proposal ID assigned by the counter |
 | `proposer` | `Address` | `ScVal::Address` | Owner who created the proposal |
-| `to` | `Address` | `ScVal::Address` | Recipient address of the transfer |
-| `amount` | `i128` | `ScVal::I128` | Transfer amount (see [Token Amounts](#token-amounts-and-decimals)) |
 | `threshold` | `u32` | `ScVal::U32` | Approval threshold in effect at creation |
+| `category` | `ProposalCategory` | `ScVal::U32` (enum discriminant) | Spending category tag (`Transfer`, `Payroll`, `Grant`, `Ops`, `Other`) |
+| `transfers` | `Vec<Transfer>` | `ScVal::Vec` | Asset transfers attached to the proposal; empty for governance proposals (add/remove owner, change threshold, spending limit) |
+| `quorum_weight` | `u32` | `ScVal::U32` | The weighted quorum this proposal must reach to become `Ready`. Snapshotted from the threshold at the moment of creation so auditors can reconstruct the exact approval requirement even if the threshold is changed by a later governance proposal. |
+| `total_weight_at_creation` | `u32` | `ScVal::U32` | Sum of all owner weights at the moment this proposal was created. Because owners can be added, removed, or re-weighted after creation, this field is the only way to recover the original total-weight context from the event log alone — it is not derivable from current contract state once ownership changes. |
 
 ```rust
 struct ProposalCreatedEvent {
     id: u64,
     proposer: Address,
-    to: Address,
-    amount: i128,
     threshold: u32,
+    category: ProposalCategory,
+    transfers: Vec<Transfer>,
+    quorum_weight: u32,
+    total_weight_at_creation: u32,
 }
 ```
 


### PR DESCRIPTION
closes #268

Extend ProposalCreatedEvent with quorum_weight and total_weight_at_creation

Once owner weights can change over time, the live contract state alone is no longer enough to reconstruct what "reaching quorum" meant at the moment a proposal was created. An auditor looking at an old proposal today would see the current total weight — which may reflect owner additions, removals, or re-weightings that happened after the proposal was created — not the weight that was actually in effect. This PR closes that gap by permanently recording both pieces of context in the event log at creation time.

ProposalCreatedEvent gains two new fields appended after the existing ones: quorum_weight (the weighted approval threshold the proposal needed to reach Ready status) and total_weight_at_creation (the sum of all owner weights at the exact moment the proposal was created). All five proposal-creation functions — create_proposal, create_add_owner_proposal, create_spending_limit_proposal, create_remove_owner_proposal, and create_change_threshold_proposal — now call read_total_weight(&env) immediately before publishing the event and populate both fields with the values in effect at that point in the transaction. All existing fields on the event are unchanged.

A new test, test_proposal_created_event_snapshots_weights, sets up a three-owner multisig with a threshold of 2 (total weight = 3), creates a proposal, and asserts the emitted event carries quorum_weight: 2 and total_weight_at_creation: 3. It then removes one owner — reducing the live total weight to 2 — and re-asserts that the already-captured event values are still 2 and 3, confirming the historical record is immutable with respect to later weight changes.

The ProposalCreatedEvent section in CONTRACT_API.md has also been corrected: the stale to and amount fields that no longer exist in the struct have been removed, the category and transfers fields that were missing from the docs have been added, and both new fields are documented with an explanation of why each matters for auditing.