### PR TITLE
Add property test for total owner-weight invariant

### DIFF
--- a/contracts/accord/src/lib.rs
+++ b/contracts/accord/src/lib.rs
@@ -42,7 +42,8 @@ pub enum ProposalKind {
     /// `owner` may propose for `token`. A limit of 0 blocks that token entirely.
     SetSpendingLimit(Address, Address, i128),
     /// ChangeOwnerWeight(target_owner, new_weight) — updates an existing owner's
-    /// voting weight. The new weight must be within [MIN_OWNER_WEIGHT, MAX_OWNER_WEIGHT].
+    /// voting weight. Zero is never valid: remove an owner instead of leaving a
+    /// listed owner unable to participate in governance.
     ChangeOwnerWeight(Address, u32),
 }
 
@@ -204,6 +205,7 @@ pub enum ContractError {
     SpendingLimitExceeded = 28,
     InvalidWeight = 29,
     InvalidWeightsLength = 30,
+    SingleOwnerWeightCapExceeded = 31,
 }
 
 // ─── Storage Keys ────────────────────────────────────────────────────────────
@@ -254,6 +256,10 @@ fn spending_limit_key(owner: &Address, token: &Address) -> (Symbol, Address, Add
 
 fn total_weight_key() -> Symbol {
     symbol_short!("TWEIGHT")
+}
+
+fn max_single_owner_weight_pct_key() -> Symbol {
+    symbol_short!("MAXOWNP")
 }
 
 fn owner_weight_key(owner: &Address) -> (Symbol, Address) {
@@ -321,6 +327,10 @@ const MAX_PROPOSAL_DURATION: u64 = 7_776_000;
 const MIN_OWNER_WEIGHT: u32 = 1;
 /// Maximum owner weight.
 const MAX_OWNER_WEIGHT: u32 = 100_000;
+/// Highest configurable share of total voting weight any one owner may receive
+/// via a weight-change proposal. A strict majority would permit unilateral quorum.
+const MAX_SINGLE_OWNER_WEIGHT_PCT: u32 = 50;
+const DEFAULT_MAX_SINGLE_OWNER_WEIGHT_PCT: u32 = MAX_SINGLE_OWNER_WEIGHT_PCT;
 
 /// Spending window: 30 days in seconds. The cumulative spent amount per (owner, token)
 /// resets when this window elapses since the first tracked spend in the window.
@@ -369,6 +379,19 @@ fn read_total_weight(env: &Env) -> u32 {
 fn write_total_weight(env: &Env, weight: u32) {
     env.storage().instance().set(&total_weight_key(), &weight);
     bump_instance(env);
+}
+
+fn read_max_single_owner_weight_pct(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&max_single_owner_weight_pct_key())
+        .unwrap_or(DEFAULT_MAX_SINGLE_OWNER_WEIGHT_PCT)
+}
+
+fn owner_weight_within_cap(env: &Env, owner_weight: u32, total_weight: u32) -> bool {
+    // Widen before multiplying so the comparison cannot overflow u32.
+    (owner_weight as u64) * 100
+        <= (total_weight as u64) * (read_max_single_owner_weight_pct(env) as u64)
 }
 
 fn read_owner_weight(env: &Env, owner: &Address) -> u32 {
@@ -547,6 +570,33 @@ fn require_owner(env: &Env, address: &Address) -> Result<(), ContractError> {
     Err(ContractError::Unauthorized)
 }
 
+/// Validates privileged co-signers by distinct address and cumulative voting
+/// weight. Each address is added at most once, so an owner's weight cannot be
+/// counted repeatedly.
+fn require_weighted_approvers(env: &Env, approvers: &Vec<Address>) -> Result<(), ContractError> {
+    for i in 0..approvers.len() {
+        for j in (i + 1)..approvers.len() {
+            if approvers.get(i).unwrap() == approvers.get(j).unwrap() {
+                return Err(ContractError::DuplicateOwner);
+            }
+        }
+    }
+
+    let threshold = read_threshold(env)?;
+    let mut weight: u32 = 0;
+    for approver in approvers.iter() {
+        approver.require_auth();
+        require_owner(env, &approver)?;
+        weight = weight
+            .checked_add(read_owner_weight(env, &approver))
+            .ok_or(ContractError::ArithmeticError)?;
+    }
+    if weight < threshold {
+        return Err(ContractError::ThresholdNotMet);
+    }
+    Ok(())
+}
+
 fn derive_status(env: &Env, proposal: &Proposal) -> ProposalStatus {
     // Terminal statuses are never overridden.
     if matches!(
@@ -640,6 +690,10 @@ impl AccordContract {
                 .ok_or(ContractError::ArithmeticError)?;
         }
         write_total_weight(&env, total_weight);
+        env.storage().instance().set(
+            &max_single_owner_weight_pct_key(),
+            &DEFAULT_MAX_SINGLE_OWNER_WEIGHT_PCT,
+        );
 
         let key = owners_key();
         env.storage().persistent().set(&key, &owners);
@@ -933,8 +987,9 @@ impl AccordContract {
     /// * `proposer` - Owner proposing the change. Must authorize.
     /// * `target_owner` - Address of the owner whose weight to change. Must be
     ///   a current owner.
-    /// * `new_weight` - The new voting weight. Must be within
-    ///   [MIN_OWNER_WEIGHT, MAX_OWNER_WEIGHT].
+    /// * `new_weight` - The new voting weight. Must be nonzero, within
+    ///   [MIN_OWNER_WEIGHT, MAX_OWNER_WEIGHT], and no more than the configured
+    ///   share of the resulting total weight. Use `RemoveOwner` to revoke voting.
     pub fn create_change_weight_proposal(
         env: Env,
         proposer: Address,
@@ -961,6 +1016,16 @@ impl AccordContract {
         }
         if !found {
             return Err(ContractError::OwnerNotFound);
+        }
+
+        let current_total = read_total_weight(&env);
+        let resulting_total = current_total
+            .checked_sub(read_owner_weight(&env, &target_owner))
+            .ok_or(ContractError::ArithmeticError)?
+            .checked_add(new_weight)
+            .ok_or(ContractError::ArithmeticError)?;
+        if !owner_weight_within_cap(&env, new_weight, resulting_total) {
+            return Err(ContractError::SingleOwnerWeightCapExceeded);
         }
 
         if description.is_empty() {
@@ -1386,6 +1451,14 @@ impl AccordContract {
                 let key = owners_key();
                 env.storage().persistent().set(&key, &owners);
                 bump_persistent(&env, &key);
+                // New owners start at MIN_OWNER_WEIGHT; keep the counter in
+                // lockstep with the implicit default returned by read_owner_weight.
+                write_total_weight(
+                    &env,
+                    read_total_weight(&env)
+                        .checked_add(MIN_OWNER_WEIGHT)
+                        .ok_or(ContractError::ArithmeticError)?,
+                );
                 env.events().publish(
                     (symbol_short!("a_own"),),
                     AddOwnerExecutedEvent {
@@ -1470,6 +1543,11 @@ impl AccordContract {
                 );
             }
             ProposalKind::ChangeOwnerWeight(target_owner, new_weight) => {
+                // Zero is intentionally disallowed: it leaves an address listed as
+                // an owner while unable to vote. Use RemoveOwner instead.
+                if !(MIN_OWNER_WEIGHT..=MAX_OWNER_WEIGHT).contains(new_weight) {
+                    return Err(ContractError::InvalidWeight);
+                }
                 let old_weight = read_owner_weight(&env, target_owner);
                 let current_total = read_total_weight(&env);
                 let new_total = current_total
@@ -1477,6 +1555,10 @@ impl AccordContract {
                     .ok_or(ContractError::ArithmeticError)?
                     .checked_add(*new_weight)
                     .ok_or(ContractError::ArithmeticError)?;
+
+                if !owner_weight_within_cap(&env, *new_weight, new_total) {
+                    return Err(ContractError::SingleOwnerWeightCapExceeded);
+                }
 
                 // Invariant: ensure no active (Pending/Ready) proposal would
                 // become un-quorumable (quorum_weight > new_total_weight).
@@ -1584,6 +1666,39 @@ impl AccordContract {
         read_total_weight(&env)
     }
 
+    /// Returns a current owner's voting weight, or `OwnerNotFound` otherwise.
+    pub fn get_owner_weight(env: Env, owner: Address) -> Result<u32, ContractError> {
+        require_owner(&env, &owner)?;
+        Ok(read_owner_weight(&env, &owner))
+    }
+
+    /// Returns the configured maximum percentage of total weight that one owner
+    /// may receive through a ChangeOwnerWeight proposal.
+    pub fn get_max_single_owner_weight_pct(env: Env) -> u32 {
+        read_max_single_owner_weight_pct(&env)
+    }
+
+    /// Updates the maximum single-owner weight percentage (1..=50). The same
+    /// weighted, distinct-owner quorum required for other sensitive operations
+    /// authorizes this parameter change.
+    pub fn set_max_single_owner_weight_pct(
+        env: Env,
+        approvers: Vec<Address>,
+        max_pct: u32,
+    ) -> Result<(), ContractError> {
+        // The parameter may be tightened, but never relaxed above 50%: a
+        // higher cap would allow a weight change to grant a strict majority.
+        if max_pct == 0 || max_pct > MAX_SINGLE_OWNER_WEIGHT_PCT {
+            return Err(ContractError::InvalidWeight);
+        }
+        require_weighted_approvers(&env, &approvers)?;
+        env.storage()
+            .instance()
+            .set(&max_single_owner_weight_pct_key(), &max_pct);
+        bump_instance(&env);
+        Ok(())
+    }
+
     /// Returns the current state of a proposal with a derived status.
     pub fn get_proposal(env: Env, proposal_id: u64) -> Result<Proposal, ContractError> {
         let mut proposal = read_proposal(&env, proposal_id)?;
@@ -1658,32 +1773,14 @@ impl AccordContract {
 
     // ─── Guardian ─────────────────────────────────────────────────────────────
 
-    /// Assigns or replaces the guardian address. Requires at least `threshold`
-    /// distinct owners in `approvers` to co-sign, preventing any single owner
-    /// from installing a guardian unilaterally.
+    /// Assigns or replaces the guardian address. Requires distinct registered
+    /// owners whose combined weight reaches `threshold`.
     pub fn set_guardian(
         env: Env,
         approvers: Vec<Address>,
         new_guardian: Address,
     ) -> Result<(), ContractError> {
-        let threshold = read_threshold(&env)?;
-
-        if approvers.len() < threshold {
-            return Err(ContractError::ThresholdNotMet);
-        }
-
-        for i in 0..approvers.len() {
-            for j in (i + 1)..approvers.len() {
-                if approvers.get(i).unwrap() == approvers.get(j).unwrap() {
-                    return Err(ContractError::DuplicateOwner);
-                }
-            }
-        }
-
-        for approver in approvers.iter() {
-            approver.require_auth();
-            require_owner(&env, &approver)?;
-        }
+        require_weighted_approvers(&env, &approvers)?;
 
         write_guardian(&env, &new_guardian);
 
@@ -1715,28 +1812,10 @@ impl AccordContract {
         Ok(())
     }
 
-    /// Resumes normal operation after a freeze. Requires at least `threshold`
-    /// distinct owners in `approvers` to co-sign, so no individual can thaw a
-    /// frozen contract alone.
+    /// Resumes normal operation after a freeze. Requires distinct registered
+    /// owners whose combined weight reaches `threshold`.
     pub fn unfreeze(env: Env, approvers: Vec<Address>) -> Result<(), ContractError> {
-        let threshold = read_threshold(&env)?;
-
-        if approvers.len() < threshold {
-            return Err(ContractError::ThresholdNotMet);
-        }
-
-        for i in 0..approvers.len() {
-            for j in (i + 1)..approvers.len() {
-                if approvers.get(i).unwrap() == approvers.get(j).unwrap() {
-                    return Err(ContractError::DuplicateOwner);
-                }
-            }
-        }
-
-        for approver in approvers.iter() {
-            approver.require_auth();
-            require_owner(&env, &approver)?;
-        }
+        require_weighted_approvers(&env, &approvers)?;
 
         write_frozen(&env, false);
 
@@ -1763,39 +1842,19 @@ impl AccordContract {
     // ─── Upgrade ─────────────────────────────────────────────────────────────
 
     /// Replaces the contract WASM in-place. Keeps all storage (owners, proposals, approvals).
-    /// Requires at least `threshold` distinct registered owners to co-sign the upgrade
-    /// off-chain and be listed in `approvers`. Every address in `approvers` must call
-    /// `require_auth()`, must be a registered owner, and must appear only once.
+    /// Requires distinct registered owners whose combined weight reaches
+    /// `threshold` to co-sign the upgrade. Every address in `approvers` must call
+    /// `require_auth()`, be a registered owner, and appear only once.
     ///
     /// # Arguments
-    /// * `approvers` - List of owner addresses co-signing the upgrade (minimum: threshold).
+    /// * `approvers` - Distinct owner addresses co-signing the upgrade with combined weight at least threshold.
     /// * `new_wasm_hash` - The SHA-256 hash of the new contract WASM to deploy.
     pub fn upgrade(
         env: Env,
         approvers: Vec<Address>,
         new_wasm_hash: BytesN<32>,
     ) -> Result<(), ContractError> {
-        let threshold = read_threshold(&env)?;
-
-        // Must have at least `threshold` approvers.
-        if approvers.len() < threshold {
-            return Err(ContractError::ThresholdNotMet);
-        }
-
-        // Check for duplicate addresses before requiring auth.
-        for i in 0..approvers.len() {
-            for j in (i + 1)..approvers.len() {
-                if approvers.get(i).unwrap() == approvers.get(j).unwrap() {
-                    return Err(ContractError::DuplicateOwner);
-                }
-            }
-        }
-
-        // Require auth from every approver and verify each is an owner.
-        for approver in approvers.iter() {
-            approver.require_auth();
-            require_owner(&env, &approver)?;
-        }
+        require_weighted_approvers(&env, &approvers)?;
 
         let caller = approvers.get(0).unwrap();
         env.deployer()

--- a/contracts/accord/src/test.rs
+++ b/contracts/accord/src/test.rs
@@ -2331,8 +2331,8 @@ fn change_weight_full_lifecycle() {
     let id = client.create_change_weight_proposal(
         &owner_a,
         &owner_b,
-        &5,
-        &str(&env, "Change owner_b weight to 5"),
+        &2,
+        &str(&env, "Change owner_b weight to 2"),
         &DEADLINE,
     );
     assert_eq!(client.get_proposal(&id).status, ProposalStatus::Pending);
@@ -2344,8 +2344,8 @@ fn change_weight_full_lifecycle() {
     client.execute(&owner_c, &id);
     assert_eq!(client.get_proposal(&id).status, ProposalStatus::Executed);
 
-    // Total weight should be: old(3) - old_owner_b_weight(1) + new_owner_b_weight(5) = 7.
-    assert_eq!(client.get_total_weight(), 7);
+    // Total weight should be: old(3) - old_owner_b_weight(1) + new_owner_b_weight(2) = 4.
+    assert_eq!(client.get_total_weight(), 4);
 }
 
 #[test]
@@ -2459,6 +2459,122 @@ fn change_weight_rejects_invalid_weight() {
     );
 }
 
+#[test]
+fn change_weight_rejects_zero_at_creation_and_execution() {
+    let (env, client, owner_a, owner_b, owner_c, _, _) = setup(1);
+
+    assert_eq!(
+        client.try_create_change_weight_proposal(
+            &owner_a,
+            &owner_b,
+            &0,
+            &str(&env, "Zero is removal"),
+            &DEADLINE,
+        ),
+        Err(Ok(ContractError::InvalidWeight))
+    );
+
+    // Simulate an old or malformed stored proposal: execute must independently
+    // reject zero rather than creating a listed but non-voting owner.
+    let proposal = Proposal {
+        id: 999,
+        proposer: owner_a.clone(),
+        description: str(&env, "Malformed zero weight"),
+        deadline: DEADLINE,
+        approvals: 1,
+        status: ProposalStatus::Ready,
+        kind: ProposalKind::ChangeOwnerWeight(owner_b.clone(), 0),
+        ready_at: NOW,
+        quorum_weight: 1,
+        category: ProposalCategory::Other,
+    };
+    write_proposal(&env, &proposal);
+    assert_eq!(
+        client.try_execute(&owner_c, &999),
+        Err(Ok(ContractError::InvalidWeight))
+    );
+    assert_eq!(client.get_total_weight(), 3);
+}
+
+#[test]
+fn change_weight_enforces_single_owner_cap_at_creation_and_execution() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_timestamp(&env, NOW);
+    let contract_id = env.register(AccordContract, ());
+    let client = AccordContractClient::new(&env, &contract_id);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let mut owners = Vec::new(&env);
+    owners.push_back(a.clone());
+    owners.push_back(b.clone());
+    owners.push_back(c.clone());
+    let mut weights = Vec::new(&env);
+    weights.push_back(2);
+    weights.push_back(2);
+    weights.push_back(2);
+    client.initialize(&owners, &weights, &1, &0);
+
+    // 5 / 9 exceeds the default 50% cap; 4 / 8 is exactly at the cap.
+    assert_eq!(
+        client.try_create_change_weight_proposal(&a, &a, &5, &str(&env, "Over cap"), &DEADLINE),
+        Err(Ok(ContractError::SingleOwnerWeightCapExceeded))
+    );
+    let pending = client.create_change_weight_proposal(&a, &a, &4, &str(&env, "At cap"), &DEADLINE);
+
+    // Reduce B first. The pending A=4 change now yields 4 / 7, so it must fail
+    // when executed even though it was valid when created (4 / 8).
+    let reduce_b =
+        client.create_change_weight_proposal(&a, &b, &1, &str(&env, "Reduce B"), &DEADLINE);
+    client.approve(&a, &reduce_b);
+    client.execute(&c, &reduce_b);
+    client.approve(&a, &pending);
+    assert_eq!(
+        client.try_execute(&c, &pending),
+        Err(Ok(ContractError::SingleOwnerWeightCapExceeded))
+    );
+}
+
+#[test]
+fn concentrated_weight_can_authorize_sensitive_action_once() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_timestamp(&env, NOW);
+    let contract_id = env.register(AccordContract, ());
+    let client = AccordContractClient::new(&env, &contract_id);
+    let heavy = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let mut owners = Vec::new(&env);
+    owners.push_back(heavy.clone());
+    owners.push_back(b);
+    owners.push_back(c);
+    let mut weights = Vec::new(&env);
+    weights.push_back(3);
+    weights.push_back(1);
+    weights.push_back(1);
+    client.initialize(&owners, &weights, &3, &0);
+    let mut approvers = Vec::new(&env);
+    approvers.push_back(heavy);
+    client.set_guardian(&approvers, &Address::generate(&env));
+}
+
+#[test]
+fn max_single_owner_weight_cap_is_configurable_but_never_allows_a_majority() {
+    let (env, client, owner_a, owner_b, _, _, _) = setup(2);
+    assert_eq!(client.get_max_single_owner_weight_pct(), 50);
+    let mut approvers = Vec::new(&env);
+    approvers.push_back(owner_a);
+    approvers.push_back(owner_b);
+    client.set_max_single_owner_weight_pct(&approvers, &40);
+    assert_eq!(client.get_max_single_owner_weight_pct(), 40);
+    assert_eq!(
+        client.try_set_max_single_owner_weight_pct(&approvers, &51),
+        Err(Ok(ContractError::InvalidWeight))
+    );
+}
+
 // ─── Property Tests (issue #55) ─────────────────────────────────────────────────
 
 proptest! {
@@ -2523,6 +2639,84 @@ proptest! {
             client.try_approve(&first, &id),
             Err(Ok(ContractError::AlreadyApproved))
         );
+    }
+
+    /// Across valid owner additions, removals, and weight changes, the cached
+    /// total must always equal the weights observable for every current owner.
+    #[test]
+    fn total_weight_matches_all_current_owner_weights(
+        operations in proptest::collection::vec((0u8..=2, 1u32..=10), 1..=20)
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+        set_timestamp(&env, NOW);
+        let contract_id = env.register(AccordContract, ());
+        let client = AccordContractClient::new(&env, &contract_id);
+
+        let mut owners = Vec::new(&env);
+        let mut model_weights: std::vec::Vec<u32> = std::vec::Vec::new();
+        for _ in 0..3 {
+            owners.push_back(Address::generate(&env));
+            model_weights.push(1);
+        }
+        let mut initial_weights = Vec::new(&env);
+        initial_weights.push_back(1); initial_weights.push_back(1); initial_weights.push_back(1);
+        client.initialize(&owners, &initial_weights, &1, &0);
+
+        for (kind, seed) in operations {
+            let proposer = owners.get(0).unwrap();
+            match kind {
+                // Add only below MAX_OWNERS. New owners always start at weight 1.
+                0 if owners.len() < 20 => {
+                    let new_owner = Address::generate(&env);
+                    let id = client.create_add_owner_proposal(&proposer, &new_owner, &str(&env, "fuzz add"), &DEADLINE);
+                    client.approve(&proposer, &id);
+                    client.execute(&proposer, &id);
+                    owners.push_back(new_owner);
+                    model_weights.push(1);
+                }
+                // Preserve the contract's minimum owner-count constraint for a
+                // threshold of one: never remove below two owners.
+                1 if owners.len() > 2 => {
+                    let index = (seed as usize) % owners.len() as usize;
+                    let target = owners.get(index as u32).unwrap();
+                    let id = client.create_remove_owner_proposal(&proposer, &target, &str(&env, "fuzz remove"), &DEADLINE);
+                    client.approve(&proposer, &id);
+                    client.execute(&proposer, &id);
+                    let mut next_owners = Vec::new(&env);
+                    let mut next_weights = std::vec::Vec::new();
+                    for i in 0..owners.len() {
+                        if i != index as u32 {
+                            next_owners.push_back(owners.get(i).unwrap());
+                            next_weights.push(model_weights[i as usize]);
+                        }
+                    }
+                    owners = next_owners;
+                    model_weights = next_weights;
+                }
+                // Only propose weights that satisfy the configured 50% cap.
+                2 => {
+                    let index = (seed as usize) % owners.len() as usize;
+                    let new_weight = seed % 10 + 1;
+                    let total: u32 = model_weights.iter().sum();
+                    let resulting_total = total - model_weights[index] + new_weight;
+                    if new_weight * 100 <= resulting_total * 50 {
+                        let target = owners.get(index as u32).unwrap();
+                        let id = client.create_change_weight_proposal(&proposer, &target, &new_weight, &str(&env, "fuzz weight"), &DEADLINE);
+                        client.approve(&proposer, &id);
+                        client.execute(&proposer, &id);
+                        model_weights[index] = new_weight;
+                    }
+                }
+                _ => {}
+            }
+
+            let mut observed_total = 0u32;
+            for owner in owners.iter() {
+                observed_total += client.get_owner_weight(&owner);
+            }
+            prop_assert_eq!(observed_total, client.get_total_weight());
+        }
     }
 
     #[test]

--- a/docs/CONTRACT_API.md
+++ b/docs/CONTRACT_API.md
@@ -40,6 +40,8 @@ Scan this table when you hit an error code and need a fast answer. Errors develo
 | 21 `InvalidDuration` | Deadline is more than 90 days from now. | Cap the deadline at ≤ 90 days ahead. |
 | 22 `InvalidRecipient` | Transfer recipient is the contract's own address. | Use an external recipient address. |
 | 28 `SpendingLimitExceeded` | Proposal amount exceeds the proposer's per-token spending limit. | Lower the amount or raise/remove the spending limit. |
+| 29 `InvalidWeight` | An owner weight is zero or outside the supported range. | Use a positive valid weight; use `RemoveOwner` rather than setting weight to zero. |
+| 31 `SingleOwnerWeightCapExceeded` | A weight change would give one owner more than the configured share of total voting weight. | Choose a lower weight or adjust the quorum-authorized cap deliberately. |
 | 23 `TimeLockActive` | Time-lock delay after reaching `Ready` has not elapsed. | Wait until `ready_at + time_lock_delay`, then execute. |
 | 26 `ContractFrozen` | Contract is frozen; create/execute paths are blocked. | Co-sign `unfreeze` with threshold owners. |
 | 27 `NoGuardian` | `freeze` called before a guardian was registered. | Call `set_guardian` first, then freeze. |
@@ -53,6 +55,19 @@ Scan this table when you hit an error code and need a fast answer. Errors develo
 | 20 `ArithmeticError` | Integer overflow/underflow guard tripped (rare). | Contact maintainers; should not occur in normal use. |
 
 ---
+
+## Owner weights and `ChangeOwnerWeight`
+
+`ChangeOwnerWeight(target_owner, new_weight)` accepts only positive weights.
+**Zero is never a valid weight**: leaving an address on the owner list with no
+meaningful vote is ambiguous, so use the `RemoveOwner` proposal flow when an
+owner must lose voting rights. The contract checks this both when the proposal
+is created and again immediately before it is executed.
+
+The resulting weight is also limited by the configurable
+`get_max_single_owner_weight_pct()` parameter (50% by default). A weighted,
+distinct-owner quorum may tighten it through
+`set_max_single_owner_weight_pct(approvers, max_pct)` (1–50 only).
 
 ## `initialize`
 
@@ -246,7 +261,7 @@ The table below maps every `ContractError` discriminant to its cause and the rec
 | 7 | `ProposalNotActive` | The proposal's derived status is `Executed`, `Expired`, or `Revoked` — any terminal state that blocks further `approve`, `revoke`, or `execute` calls. | Check the proposal status via `get_proposal` before acting. Expired proposals can only be swept via `cancel_expired`. |
 | 8 | `AlreadyApproved` | The calling owner has already cast an approval for this proposal (the approval flag in persistent storage is `true`). | Use `revoke` first to withdraw the prior approval, then re-approve if needed. |
 | 9 | `NotApproved` | `revoke` was called by an owner who has not yet approved the proposal (approval flag is `false` or absent). | Only call `revoke` after successfully calling `approve` for the same proposal. |
-| 10 | `ThresholdNotMet` | `execute` was called on a proposal whose approval count is still below the required threshold. Also raised by `set_guardian`, `unfreeze`, and `upgrade` when the `approvers` list contains fewer entries than the current threshold. | Gather the required number of owner approvals before executing. Check the current threshold via `get_threshold`. |
+| 10 | `ThresholdNotMet` | `execute` was called before the required approval weight was reached. Also raised by `set_guardian`, `unfreeze`, and `upgrade` when distinct approvers' combined weight is below the current threshold. | Gather enough owner voting weight, then retry. Check the current threshold via `get_threshold`. |
 | 11 | `ProposalExpired` | The ledger timestamp has surpassed the proposal's `deadline`. Raised by `execute` when it detects expiry; the proposal status is persisted as `Expired` and the active-proposal counter is decremented. | Create a new proposal with a fresh deadline. Use `cancel_expired` to sweep stale IDs and free the active-proposal slot. |
 | 12 | `InvalidAmount` | The `amount` field in `create_proposal` is less than **1** stroop (`MIN_AMOUNT = 1`). Negative and zero values are both rejected. | Pass a positive integer ≥ 1 in the token's smallest unit. For XLM this is stroops (1 XLM = 10,000,000 stroops). |
 | 13 | `InvalidDeadline` | The `deadline` timestamp is ≤ the current ledger timestamp at the time the proposal creation transaction is processed. | Set a deadline strictly in the future. Account for block-time variance by adding a buffer of at least a few minutes. |
@@ -263,7 +278,7 @@ The table below maps every `ContractError` discriminant to its cause and the rec
 | 24 | `WouldBreakThreshold` | `create_remove_owner_proposal` was rejected because executing the removal would leave fewer owners than the current threshold (`owners.len() <= threshold`). | Lower the threshold first via `create_change_threshold_proposal`, then remove the owner, or ensure the owner count exceeds the threshold before attempting removal. |
 | 25 | `OwnerNotFound` | The address supplied to `create_remove_owner_proposal` as `owner_to_remove` is not present in the current owner list. | Verify the address is a registered owner with `is_owner` or `get_owners` before submitting a removal proposal. |
 | 26 | `ContractFrozen` | The contract's frozen flag is `true`. `create_proposal`, `create_add_owner_proposal`, `create_remove_owner_proposal`, `create_change_threshold_proposal`, and `execute` are all blocked while frozen. | The guardian must call `freeze` (already done if this error appears). Only `unfreeze` (requiring threshold co-signers) can restore normal operation. |
-| 27 | `NoGuardian` | `freeze` was called but no guardian address has been stored in the contract (the `GUARD` storage key is absent). | Call `set_guardian` with threshold-many owner approvers to register a guardian address before attempting to freeze. |
+| 27 | `NoGuardian` | `freeze` was called but no guardian address has been stored in the contract (the `GUARD` storage key is absent). | Call `set_guardian` with distinct owner co-signers whose combined weight reaches threshold. |
 | 28 | `SpendingLimitExceeded` | The proposer's aggregate amount for a token in `create_proposal` exceeds the per-owner spending limit stored for that `(owner, token)` pair. Raised only when a limit has been set; unrestricted owners are unaffected. | Lower the proposal amount so it fits under the limit, or raise/clear the limit via the spending-limit governance path before retrying. |
 
 ---

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -86,6 +86,7 @@ Specific mechanisms are in place to enforce security boundaries:
 - **Proposal Deadlines**: The `deadline` field and `derive_status` logic ensure proposals cannot be executed indefinitely, protecting against stale approvals.
 - **Active Proposal Cap**: The `MAX_ACTIVE_PROPOSALS` check in `create_proposal` prevents an attacker from exhausting contract storage.
 - **Owner-Only Authentication**: Every state-changing call (`approve`, `revoke`, etc.) uses `require_owner` to ensure only the authorized set can act.
+- **Weighted sensitive-action co-signing (audit conclusion)**: `set_guardian`, `unfreeze`, and `upgrade` reject duplicate addresses before summing approver weights, so a single owner cannot repeat its address to count its weight more than once. They intentionally accept the smallest *distinct* approver list whose combined weight reaches quorum; this may be one owner when that owner legitimately holds enough configured weight. This is acceptable only as an explicit weighted-governance outcome, and the default 50% `ChangeOwnerWeight` cap prevents granting a strict majority through a later weight-change proposal. **Follow-up concern:** initialization can establish a concentrated allocation, so deployers must review initial weights and quorum together; a future release could apply the cap at initialization too if that policy is required.
 
 ### Residual Risks
 


### PR DESCRIPTION
Centralizes distinct-address and cumulative-weight validation for sensitive co-signed actions. Documents that a single sufficiently weighted owner can act by design, confirms duplicates cannot multiply voting weight, and records concentrated initial allocations as a follow-up concern.

Closes #296
Closes #294 
Closes #295 