### PR TITLE
Feat/category filter security docs api docs weighted owners

### DIFF
--- a/docs/CONTRACT_API.md
+++ b/docs/CONTRACT_API.md
@@ -278,6 +278,341 @@ Returns `true` if `owner` has approved `proposal_id`.
 
 ---
 
+## Governance Proposals
+
+These four functions create **governance proposals**. Like `create_proposal`, each returns a new proposal ID and then follows the standard **create → approve → execute** lifecycle: the returned proposal must reach the approval threshold via `approve` and then be run with `execute` before it takes effect. All four require the `proposer` to be a current owner and require the contract not to be frozen, and all enforce the same `description` (1–300 characters), `deadline` (strictly future, ≤ 90 days ahead), and active-proposal-cap (≤ 50) rules as `create_proposal`. Each emits `("created",)` → `ProposalCreatedEvent` with an empty `transfers` list and `category = Other`.
+
+The JavaScript examples below assume `server` (an `rpc.Server`), `CONTRACT_ID`, and `networkPassphrase` are already defined, and reuse this helper to build, prepare, sign, and submit an owner-authorized write:
+
+```js
+import { Contract, TransactionBuilder, nativeToScVal, xdr } from "@stellar/stellar-sdk";
+
+const contract = new Contract(CONTRACT_ID);
+
+// Build → prepare (simulate) → sign with the proposer's key → submit.
+async function submitOwnerCall(op, proposerKeypair) {
+  const account = await server.getAccount(proposerKeypair.publicKey());
+  const tx = new TransactionBuilder(account, { fee: "100", networkPassphrase })
+    .addOperation(op)
+    .setTimeout(30)
+    .build();
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(proposerKeypair); // or a wallet's signTransaction()
+  return server.sendTransaction(prepared);
+}
+```
+
+### `create_add_owner_proposal`
+
+```rust
+fn create_add_owner_proposal(
+    env: Env,
+    proposer: Address,
+    new_owner: Address,
+    description: String,
+    deadline: u64,
+) -> Result<u64, ContractError>
+```
+
+Proposes adding `new_owner` to the multisig. On execution the new owner is stored with the minimum voting weight of `1`. Returns the new proposal ID.
+
+| Parameter | Type | Constraints |
+|-----------|------|-------------|
+| `proposer` | `Address` | Must be an owner. Must authorize. |
+| `new_owner` | `Address` | Must not already be an owner. Current owner count must be `< 20` (`MAX_OWNERS`). |
+| `description` | `String` | 1–300 characters |
+| `deadline` | `u64` | > current ledger timestamp, ≤ now + 90 days |
+
+**Emits:** `("created",)` → `ProposalCreatedEvent`
+
+**Errors:** `Unauthorized`, `ContractFrozen`, `DuplicateOwner`, `InvalidOwners`, `EmptyDescription`, `DescriptionTooLong`, `InvalidDeadline`, `InvalidDuration`, `TooManyActiveProposals`
+
+```js
+await submitOwnerCall(
+  contract.call(
+    "create_add_owner_proposal",
+    nativeToScVal(proposer, { type: "address" }),
+    nativeToScVal(newOwner, { type: "address" }),
+    nativeToScVal(description, { type: "string" }),
+    nativeToScVal(BigInt(deadline), { type: "u64" }),
+  ),
+  proposerKeypair,
+);
+```
+
+### `create_remove_owner_proposal`
+
+```rust
+fn create_remove_owner_proposal(
+    env: Env,
+    proposer: Address,
+    owner_to_remove: Address,
+    description: String,
+    deadline: u64,
+) -> Result<u64, ContractError>
+```
+
+Proposes removing `owner_to_remove` from the multisig. Rejected at creation if the removal would drop the remaining total owner weight below the current threshold. Returns the new proposal ID.
+
+| Parameter | Type | Constraints |
+|-----------|------|-------------|
+| `proposer` | `Address` | Must be an owner. Must authorize. |
+| `owner_to_remove` | `Address` | Must be a current owner. Remaining total weight after removal must stay ≥ threshold. |
+| `description` | `String` | 1–300 characters |
+| `deadline` | `u64` | > current ledger timestamp, ≤ now + 90 days |
+
+**Emits:** `("created",)` → `ProposalCreatedEvent`
+
+**Errors:** `Unauthorized`, `ContractFrozen`, `OwnerNotFound`, `WouldBreakThreshold`, `EmptyDescription`, `DescriptionTooLong`, `InvalidDeadline`, `InvalidDuration`, `TooManyActiveProposals`, `ArithmeticError`
+
+```js
+await submitOwnerCall(
+  contract.call(
+    "create_remove_owner_proposal",
+    nativeToScVal(proposer, { type: "address" }),
+    nativeToScVal(ownerToRemove, { type: "address" }),
+    nativeToScVal(description, { type: "string" }),
+    nativeToScVal(BigInt(deadline), { type: "u64" }),
+  ),
+  proposerKeypair,
+);
+```
+
+### `create_change_threshold_proposal`
+
+```rust
+fn create_change_threshold_proposal(
+    env: Env,
+    proposer: Address,
+    new_threshold: u32,
+    description: String,
+    deadline: u64,
+) -> Result<u64, ContractError>
+```
+
+Proposes changing the approval threshold. The threshold is an **absolute weight value**, so it is validated against the current total owner weight rather than the owner count. Returns the new proposal ID.
+
+| Parameter | Type | Constraints |
+|-----------|------|-------------|
+| `proposer` | `Address` | Must be an owner. Must authorize. |
+| `new_threshold` | `u32` | ≥ 1 and ≤ current total owner weight |
+| `description` | `String` | 1–300 characters |
+| `deadline` | `u64` | > current ledger timestamp, ≤ now + 90 days |
+
+**Emits:** `("created",)` → `ProposalCreatedEvent`
+
+**Errors:** `Unauthorized`, `ContractFrozen`, `InvalidThreshold`, `EmptyDescription`, `DescriptionTooLong`, `InvalidDeadline`, `InvalidDuration`, `TooManyActiveProposals`
+
+```js
+await submitOwnerCall(
+  contract.call(
+    "create_change_threshold_proposal",
+    nativeToScVal(proposer, { type: "address" }),
+    nativeToScVal(newThreshold, { type: "u32" }),
+    nativeToScVal(description, { type: "string" }),
+    nativeToScVal(BigInt(deadline), { type: "u64" }),
+  ),
+  proposerKeypair,
+);
+```
+
+### `create_spending_limit_proposal`
+
+```rust
+fn create_spending_limit_proposal(
+    env: Env,
+    proposer: Address,
+    owner: Address,
+    token: Address,
+    limit: i128,
+    description: String,
+    deadline: u64,
+) -> Result<u64, ContractError>
+```
+
+Proposes setting (or changing) a per-owner, per-token spending limit. Once executed, the limit caps the cumulative amount `owner` may propose for `token` within a fixed 30-day window; it is enforced in `create_proposal`. A `limit` of `0` blocks that token entirely for that owner. Returns the new proposal ID.
+
+| Parameter | Type | Constraints |
+|-----------|------|-------------|
+| `proposer` | `Address` | Must be an owner. Must authorize. |
+| `owner` | `Address` | The owner the limit applies to |
+| `token` | `Address` | The token the limit applies to |
+| `limit` | `i128` | ≥ 0 (`0` blocks the token for that owner) |
+| `description` | `String` | 1–300 characters |
+| `deadline` | `u64` | > current ledger timestamp, ≤ now + 90 days |
+
+**Emits:** `("created",)` → `ProposalCreatedEvent`
+
+**Errors:** `Unauthorized`, `ContractFrozen`, `InvalidAmount`, `EmptyDescription`, `DescriptionTooLong`, `InvalidDeadline`, `InvalidDuration`, `TooManyActiveProposals`
+
+```js
+await submitOwnerCall(
+  contract.call(
+    "create_spending_limit_proposal",
+    nativeToScVal(proposer, { type: "address" }),
+    nativeToScVal(owner, { type: "address" }),
+    nativeToScVal(token, { type: "address" }),
+    nativeToScVal(BigInt(limit), { type: "i128" }),
+    nativeToScVal(description, { type: "string" }),
+    nativeToScVal(BigInt(deadline), { type: "u64" }),
+  ),
+  proposerKeypair,
+);
+```
+
+---
+
+## Guardian & Emergency Pause
+
+The guardian mechanism provides an emergency pause. **Unlike the create → approve → execute proposal flow used everywhere else in the contract, `set_guardian` and `unfreeze` are single-transaction, multi-owner calls.** They each take a `Vec<Address>` of *distinct* owners who must **all sign the same transaction**, and whose combined voting weight must reach the current threshold — there is no separate approval step and no stored proposal, so authorization and effect happen atomically in one call. `freeze`, by contrast, is authorized by the single registered guardian.
+
+Because `set_guardian` and `unfreeze` require several signatures on one transaction, each co-signing owner must add their signature to the **same** transaction envelope before it is submitted:
+
+```js
+import { Contract, TransactionBuilder, nativeToScVal, xdr } from "@stellar/stellar-sdk";
+
+const contract = new Contract(CONTRACT_ID);
+
+// Encode a Vec<Address> of approver addresses.
+function approversScVal(approvers) {
+  return xdr.ScVal.scvVec(
+    approvers.map((a) => nativeToScVal(a, { type: "address" })),
+  );
+}
+
+// Build one transaction and collect a signature from every co-signing owner.
+async function submitCoSignedCall(op, sourceKeypair, coSignerKeypairs) {
+  const account = await server.getAccount(sourceKeypair.publicKey());
+  const tx = new TransactionBuilder(account, { fee: "100", networkPassphrase })
+    .addOperation(op)
+    .setTimeout(30)
+    .build();
+  const prepared = await server.prepareTransaction(tx);
+  for (const kp of coSignerKeypairs) prepared.sign(kp); // every approver signs the same tx
+  return server.sendTransaction(prepared);
+}
+```
+
+### `set_guardian`
+
+```rust
+fn set_guardian(env: Env, approvers: Vec<Address>, new_guardian: Address) -> Result<(), ContractError>
+```
+
+Assigns or replaces the guardian address. Requires distinct owner `approvers` whose combined weight reaches the threshold, all signing the same transaction.
+
+| Parameter | Type | Constraints |
+|-----------|------|-------------|
+| `approvers` | `Vec<Address>` | Distinct current owners; each must authorize; combined weight ≥ threshold |
+| `new_guardian` | `Address` | The address to register as guardian |
+
+**Emits:** `("guard_set",)` → `GuardianSetEvent`
+
+**Errors:** `NotInitialized`, `DuplicateOwner`, `Unauthorized`, `ThresholdNotMet`
+
+```js
+await submitCoSignedCall(
+  contract.call(
+    "set_guardian",
+    approversScVal(approvers),
+    nativeToScVal(newGuardian, { type: "address" }),
+  ),
+  approverKeypairs[0],
+  approverKeypairs,
+);
+```
+
+### `freeze`
+
+```rust
+fn freeze(env: Env, guardian: Address) -> Result<(), ContractError>
+```
+
+Immediately freezes the contract, blocking new proposal creation and all execution. **Only the currently registered guardian may call this**, and only after a guardian has been set.
+
+| Parameter | Type | Constraints |
+|-----------|------|-------------|
+| `guardian` | `Address` | Must equal the registered guardian. Must authorize. |
+
+**Emits:** `("frozen",)` → `FrozenEvent`
+
+**Errors:** `NoGuardian`, `Unauthorized`
+
+```js
+const account = await server.getAccount(guardianKeypair.publicKey());
+const tx = new TransactionBuilder(account, { fee: "100", networkPassphrase })
+  .addOperation(contract.call("freeze", nativeToScVal(guardian, { type: "address" })))
+  .setTimeout(30)
+  .build();
+const prepared = await server.prepareTransaction(tx);
+prepared.sign(guardianKeypair);
+await server.sendTransaction(prepared);
+```
+
+### `unfreeze`
+
+```rust
+fn unfreeze(env: Env, approvers: Vec<Address>) -> Result<(), ContractError>
+```
+
+Resumes normal operation after a freeze. Like `set_guardian`, requires distinct owner `approvers` whose combined weight reaches the threshold, all signing the same transaction.
+
+| Parameter | Type | Constraints |
+|-----------|------|-------------|
+| `approvers` | `Vec<Address>` | Distinct current owners; each must authorize; combined weight ≥ threshold |
+
+**Emits:** `("unfrozen",)` → `UnfrozenEvent`
+
+**Errors:** `NotInitialized`, `DuplicateOwner`, `Unauthorized`, `ThresholdNotMet`
+
+```js
+await submitCoSignedCall(
+  contract.call("unfreeze", approversScVal(approvers)),
+  approverKeypairs[0],
+  approverKeypairs,
+);
+```
+
+### `get_guardian`
+
+```rust
+fn get_guardian(env: Env) -> Option<Address>
+```
+
+Returns the current guardian address, or `None` (decoded as `null`/`undefined`) if no guardian has been set. Read-only; no authorization required.
+
+```js
+import { scValToNative } from "@stellar/stellar-sdk";
+
+// Read-only: simulate the call and decode the result (no signing required).
+async function simulateView(fn) {
+  const account = await server.getAccount(SIM_SOURCE); // any funded account
+  const tx = new TransactionBuilder(account, { fee: "100", networkPassphrase })
+    .addOperation(contract.call(fn))
+    .setTimeout(30)
+    .build();
+  const sim = await server.simulateTransaction(tx);
+  return scValToNative(sim.result.retval);
+}
+
+const guardian = await simulateView("get_guardian"); // "G…" string, or null if unset
+```
+
+### `is_frozen`
+
+```rust
+fn is_frozen(env: Env) -> bool
+```
+
+Returns `true` if the contract is currently frozen. Read-only; no authorization required.
+
+```js
+// Reuses the read-only simulateView helper defined for get_guardian above.
+const frozen = await simulateView("is_frozen"); // boolean
+```
+
+---
+
 ## Error Reference
 
 The table below maps every `ContractError` discriminant to its cause and the recommended remediation. All codes are `u32` values encoded as `ScVal::Error` in XDR responses.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -53,7 +53,7 @@ Known areas that require attention before mainnet:
 - There is no automatic on-chain emergency recovery; owner removal and threshold changes still require coordinated proposal approval.
 - Token contracts are validated when a proposal is created, but not re-validated at execution time, so a contract upgrade between those events can change the risk profile.
 - A malicious owner can deliberately fill the active proposal cap and temporarily block new proposals from being created.
-- The contract does not impose spending limits or per-owner quotas; the threshold is the primary access-control mechanism.
+- Per-owner, per-token spending limits are available via `SetSpendingLimit` proposals and are enforced when a transfer proposal is created, but they are opt-in: an owner with no configured limit for a given token remains unrestricted for it, so the threshold is still the primary access-control mechanism.
 
 ## Explicit Trust Assumptions
 
@@ -67,7 +67,9 @@ Known areas that require attention before mainnet:
 ### Attack Surfaces
 
 The protocol's attack surface includes the following external entry points:
-- **Public Contract Functions**: `create_proposal` (and variants), `approve`, `revoke`, `execute`, `cancel_expired` (planned), and `upgrade`. These are reachable by any actor via the Stellar network.
+- **Public Contract Functions**: `create_proposal` (and variants), `approve`, `revoke`, `execute`, `cancel_expired`, and `upgrade`. These are reachable by any actor via the Stellar network.
+- **Guardian / Emergency Pause**: `set_guardian`, `freeze`, and `unfreeze`. `set_guardian` assigns or replaces the guardian address and requires a set of *distinct* owners whose combined voting weight reaches the current threshold to co-sign in a single call. `freeze` can be called **only** by the currently registered guardian and immediately blocks new proposal creation and all proposal execution. `unfreeze` lifts the freeze and, like `set_guardian`, requires distinct owners whose combined weight reaches the threshold. A misconfigured or captured guardian key can therefore halt the contract (a denial-of-service pause), but on its own cannot move funds, change the owner set, or change the threshold.
+- **Concurrent Governance Proposals**: Two governance proposals that each pass their own creation-time checks can be approved in parallel and executed back-to-back — for example two `RemoveOwner` proposals, or a `RemoveOwner` alongside a `ChangeThreshold`. Because each creation-time check evaluates the owner set and total weight as they stand at creation, executing both together can move the owner-count or total-weight past the point where the threshold is still reachable, risking a multisig that can no longer reach quorum.
 - **Frontend Wallet Connection**: The boundary where the dApp interacts with browser-based wallets (Freighter). Malicious sites could attempt to intercept or spoof these calls.
 - **RPC Layer Boundary**: The communication path between the frontend and a Stellar RPC node. A compromised node can feed dishonest state data to the user.
 
@@ -87,12 +89,14 @@ Specific mechanisms are in place to enforce security boundaries:
 - **Active Proposal Cap**: The `MAX_ACTIVE_PROPOSALS` check in `create_proposal` prevents an attacker from exhausting contract storage.
 - **Owner-Only Authentication**: Every state-changing call (`approve`, `revoke`, etc.) uses `require_owner` to ensure only the authorized set can act.
 - **Weighted sensitive-action co-signing (audit conclusion)**: `set_guardian`, `unfreeze`, and `upgrade` reject duplicate addresses before summing approver weights, so a single owner cannot repeat its address to count its weight more than once. They intentionally accept the smallest *distinct* approver list whose combined weight reaches quorum; this may be one owner when that owner legitimately holds enough configured weight. This is acceptable only as an explicit weighted-governance outcome, and the default 50% `ChangeOwnerWeight` cap prevents granting a strict majority through a later weight-change proposal. **Follow-up concern:** initialization can establish a concentrated allocation, so deployers must review initial weights and quorum together; a future release could apply the cap at initialization too if that policy is required.
+- **Guardian Emergency Pause**: A guardian registered through `set_guardian` (itself co-signed by owners whose combined weight meets the threshold) can call `freeze` to immediately block all new proposal creation and execution the moment a compromise or incident is detected. This bounds the damage from a detected compromise: it buys time to remove an exposed owner key or investigate before any funds move, without granting the guardian any power to transfer funds or alter the owner set or threshold. Resuming normal operation requires `unfreeze`, which again needs distinct owners whose combined weight reaches the threshold — so no single party, including the guardian, can both pause and silently resume the contract.
+- **Execute-time invariant re-validation for weight changes**: Governance proposals are validated when created but executed later, so a `ChangeOwnerWeight` proposal re-checks *at execution time* that the resulting total weight would not leave any still-active (Pending/Ready) proposal un-quorumable — if any active proposal's snapshotted `quorum_weight` would exceed the new total weight, execution is rejected with `WouldBreakThreshold`. Owner-removal is guarded at creation time (a removal that would drop remaining weight below the threshold is rejected up front by `create_remove_owner_proposal`), and threshold changes are validated against total weight at creation. Because those removal and threshold checks evaluate state at creation rather than the combined effect of several proposals executing together, operators should still sequence interacting governance proposals deliberately — approving and executing one before creating the next — so two concurrent removals (or a removal plus a threshold change) cannot combine to push the multisig below a reachable quorum.
 
 ### Residual Risks
 
 The following risks are currently unmitigated by the protocol design:
 - **No SOS Recovery**: If enough owner keys are lost, there is no emergency "recovery" mode; the funds remain locked if the threshold cannot be met.
-- **Lack of Spending Limits**: There are no per-owner or per-day spending caps; once threshold is reached, any amount can be transferred.
+- **Opt-in Spending Limits**: Per-owner, per-token spending limits exist via `SetSpendingLimit` proposals and are enforced at proposal creation (against a fixed 30-day spending window). They are not applied by default, however: an owner with no configured limit for a token can still propose any amount up to the treasury balance once the threshold is reached, so unrestricted tokens remain gated only by the approval threshold.
 - **The Validation Gap**: A token contract could be upgraded to malicious code between a proposal's creation (where it is validated) and its execution.
 
 ## Responsible Disclosure

--- a/frontend/src/components/ProposalCard.test.tsx
+++ b/frontend/src/components/ProposalCard.test.tsx
@@ -21,6 +21,7 @@ vi.mock("../hooks/useContract", () => ({
 const baseProposal = (overrides: Partial<Proposal> = {}): Proposal => ({
   id: 42,
   kind: "transfer",
+  category: "transfer",
   to: "GABCDE...WXYZ",
   amount: "100",
   token: "USDC",

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
-import type { Proposal, ProposalKind } from "../types/accord";
+import type { Proposal, ProposalCategory, ProposalKind } from "../types/accord";
 import { ApprovalBar } from "./ApprovalBar";
 import { StatusBadge } from "./StatusBadge";
 import { Check, Copy, Link2 } from "lucide-react";
@@ -19,6 +19,15 @@ const KIND_LABELS: Record<ProposalKind, { title: string; badge: string }> = {
   remove_owner: { title: "Remove Owner", badge: "Governance" },
   change_threshold: { title: "Change Threshold", badge: "Governance" },
   set_spending_limit: { title: "Set Spending Limit", badge: "Spending Limit" },
+};
+
+// Colour palette per category, mirroring the pill styling used by StatusBadge.
+const CATEGORY_STYLES: Record<ProposalCategory, string> = {
+  transfer: "bg-emerald-500/10 text-emerald-400 border border-emerald-500/20",
+  payroll: "bg-violet-500/10 text-violet-400 border border-violet-500/20",
+  grant: "bg-amber-500/10 text-amber-400 border border-amber-500/20",
+  ops: "bg-sky-500/10 text-sky-400 border border-sky-500/20",
+  other: "bg-zinc-500/10 text-zinc-400 border border-zinc-500/20",
 };
 
 function KindSummary({ proposal }: { proposal: Proposal }): ReactNode {
@@ -231,6 +240,13 @@ export const ProposalCard = React.memo(function ProposalCard({
               <Link2 size={16} />
             )}
           </button>
+          <span
+            role="note"
+            aria-label={`Category: ${proposal.category}`}
+            className={`text-xs px-2 py-0.5 rounded-full font-mono capitalize ${CATEGORY_STYLES[proposal.category]}`}
+          >
+            {proposal.category}
+          </span>
           <StatusBadge status={proposal.status} />
         </div>
       </div>

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -6,7 +6,7 @@ import {
   scValToNative,
   xdr,
 } from "@stellar/stellar-sdk";
-import type { Proposal, ProposalKind, ProposalStatus } from "../types/accord";
+import type { Proposal, ProposalCategory, ProposalKind, ProposalStatus } from "../types/accord";
 import { stroopsToDisplay, formatDeadline, shortenAddr } from "./soroban";
 
 const RPC_URL = import.meta.env.VITE_SOROBAN_RPC_URL as string;
@@ -46,6 +46,32 @@ function mapStatus(raw: unknown): ProposalStatus {
     return key.toLowerCase() as ProposalStatus;
   }
   return "pending";
+}
+
+function mapCategory(raw: unknown): ProposalCategory {
+  // Soroban unit-enum variants decode either to their name as a string or to a
+  // single-key object, so handle both shapes like mapStatus does. Anything
+  // unrecognised (including an unset category) falls back to "other".
+  let key: string;
+  if (typeof raw === "string") {
+    key = raw;
+  } else if (raw && typeof raw === "object") {
+    key = Object.keys(raw as object)[0] ?? "Other";
+  } else {
+    return "other";
+  }
+  switch (key.toLowerCase()) {
+    case "transfer":
+      return "transfer";
+    case "payroll":
+      return "payroll";
+    case "grant":
+      return "grant";
+    case "ops":
+      return "ops";
+    default:
+      return "other";
+  }
 }
 
 function safeBigInt(value: unknown): bigint {
@@ -122,6 +148,7 @@ export function mapProposal(raw: any, threshold: number): Proposal {
   return {
     id: Number(raw.id),
     kind: mapped.kind,
+    category: mapCategory(raw.category),
     to: mapped.to,
     amount: mapped.amount,
     token: mapped.token,

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { Proposal, ProposalStatus } from "../types/accord";
+import type { Proposal, ProposalCategory, ProposalStatus } from "../types/accord";
 import { ProposalCard } from "../components/ProposalCard";
 import {
   getProposalsPaged,
@@ -9,6 +9,7 @@ import {
 } from "../lib/contract";
 
 type Filter = "all" | ProposalStatus;
+type CategoryFilter = "all" | ProposalCategory;
 
 const TABS: { key: Filter; label: string }[] = [
   { key: "all", label: "All" },
@@ -19,6 +20,15 @@ const TABS: { key: Filter; label: string }[] = [
   { key: "revoked", label: "Revoked" },
 ];
 
+const CATEGORY_OPTIONS: { key: CategoryFilter; label: string }[] = [
+  { key: "all", label: "All Categories" },
+  { key: "transfer", label: "Transfer" },
+  { key: "payroll", label: "Payroll" },
+  { key: "grant", label: "Grant" },
+  { key: "ops", label: "Ops" },
+  { key: "other", label: "Other" },
+];
+
 export function HistoryPage({
   proposals,
   onApprove,
@@ -27,6 +37,7 @@ export function HistoryPage({
   onApprove: (id: number) => void;
 }) {
   const [activeTab, setActiveTab] = useState<Filter>("all");
+  const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>("all");
   const [searchTerm, setSearchTerm] = useState("");
   const [proposerFilter, setProposerFilter] = useState("");
   const [displayedProposals, setDisplayedProposals] = useState<Proposal[]>(proposals);
@@ -86,6 +97,7 @@ export function HistoryPage({
 
   const filteredProposals = displayedProposals
     .filter((p) => activeTab === "all" || p.status === activeTab)
+    .filter((p) => categoryFilter === "all" || p.category === categoryFilter)
     .filter((p) =>
       p.description.toLowerCase().includes(searchTerm.toLowerCase())
     )
@@ -134,6 +146,18 @@ export function HistoryPage({
               Export CSV
             </button>
           )}
+          <select
+            value={categoryFilter}
+            onChange={(e) => setCategoryFilter(e.target.value as CategoryFilter)}
+            aria-label="Filter by category"
+            className="text-xs px-3 py-1.5 bg-zinc-900 border border-zinc-800 text-zinc-200 rounded-lg capitalize transition-colors hover:text-white focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+          >
+            {CATEGORY_OPTIONS.map((option) => (
+              <option key={option.key} value={option.key}>
+                {option.label}
+              </option>
+            ))}
+          </select>
           <div className="flex items-center gap-1 bg-zinc-900 border border-zinc-800 p-1 rounded-lg">
           {TABS.map((tab) => (
             <button
@@ -193,7 +217,7 @@ export function HistoryPage({
       <div className="space-y-3">
         {filteredProposals.length === 0 ? (
           <p className="text-zinc-600 text-sm py-8 text-center">
-            {searchTerm || proposerFilter
+            {searchTerm || proposerFilter || categoryFilter !== "all"
               ? "No proposals match your search"
               : `No ${activeTab === "all" ? "" : `${activeTab} `}proposals found`}
           </p>

--- a/frontend/src/types/accord.ts
+++ b/frontend/src/types/accord.ts
@@ -2,9 +2,12 @@ export type ProposalStatus = "pending" | "ready" | "executed" | "expired" | "rev
 
 export type ProposalKind = "transfer" | "add_owner" | "remove_owner" | "change_threshold" | "set_spending_limit";
 
+export type ProposalCategory = "transfer" | "payroll" | "grant" | "ops" | "other";
+
 export type Proposal = {
   id: number;
   kind: ProposalKind;
+  category: ProposalCategory;
   to: string;
   amount: string;
   token: string;


### PR DESCRIPTION
Closes #246
Closes #247
Closes #248
Closes #249

## Summary
Resolves three Stellar-Wave issues across the frontend and docs. The frontend now
surfaces the on-chain proposal category with a badge and a history filter; SECURITY.md's
threat model is brought back in line with the shipped contract (spending limits, guardian
pause, concurrent-governance risk); and CONTRACT_API.md gains a full reference for the
governance-proposal and guardian/emergency-pause entry points with JS SDK examples.
No contract behavior is changed.

## Changes
- Surface proposal category with filter dropdown and badge (#246)
- Correct stale threat model in SECURITY.md (#247)
- Document governance and guardian functions in CONTRACT_API.md (#248)

## Testing
- frontend: `npm run build` (tsc -b + vite) passes; `npm test` (vitest) 61/61 pass.
  `eslint` reports only 2 pre-existing set-state-in-effect errors that also fail on an
  untouched main (verified via stash) — unrelated to this PR.
- contracts: unchanged by this PR (no .rs edits).
