### PR TITLE
Add bulk owner weights view

### DIFF
--- a/contracts/accord/src/lib.rs
+++ b/contracts/accord/src/lib.rs
@@ -2056,6 +2056,18 @@ impl AccordContract {
         owners.get(owner).ok_or(ContractError::OwnerNotFound)
     }
 
+    /// Returns every current owner's address paired with their voting weight,
+    /// in a single call. Read-only; no authorization required.
+    pub fn get_owner_weights(env: Env) -> Result<Vec<OwnerWeight>, ContractError> {
+        let owners = read_owners_map(&env)?;
+        let mut result = Vec::new(&env);
+        for owner in owners.keys().iter() {
+            let weight = owners.get(owner.clone()).unwrap_or(0);
+            result.push_back(OwnerWeight { owner, weight });
+        }
+        Ok(result)
+    }
+
     /// Returns the configured maximum percentage of total weight that one owner
     /// may receive through a ChangeOwnerWeight proposal.
     pub fn get_max_single_owner_weight_pct(env: Env) -> u32 {
@@ -2127,19 +2139,6 @@ impl AccordContract {
     /// Returns all current owners.
     pub fn get_owners(env: Env) -> Result<Vec<Address>, ContractError> {
         Ok(read_owners_map(&env)?.keys())
-    }
-
-    /// Returns every current owner's address paired with their voting weight,
-    /// in a single call. The sum of the returned weights equals the current
-    /// total-weight counter. Read-only; no authorization required.
-    pub fn get_owner_weights(env: Env) -> Result<Vec<OwnerWeight>, ContractError> {
-        let owners = read_owners_map(&env)?;
-        let mut result = Vec::new(&env);
-        for owner in owners.keys().iter() {
-            let weight = owners.get(owner.clone()).unwrap_or(0);
-            result.push_back(OwnerWeight { owner, weight });
-        }
-        Ok(result)
     }
 
     /// Returns the spending limit for an (owner, token) pair, or `None` if no

--- a/contracts/accord/src/test.rs
+++ b/contracts/accord/src/test.rs
@@ -5763,6 +5763,55 @@ fn get_owner_weights_returns_all_owners_with_correct_weights() {
     assert_eq!(sum, client.get_total_weight());
 }
 
+/// A single-owner multisig must return one entry with that owner's weight.
+#[test]
+fn get_owner_weights_returns_single_owner_weight() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AccordContract, ());
+    let client = AccordContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let mut owners = Vec::new(&env);
+    owners.push_back(owner.clone());
+    let mut weights = Vec::new(&env);
+    weights.push_back(7_u32);
+    client.initialize(&owners, &weights, &1, &0);
+
+    let result = client.get_owner_weights();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result.get(0).unwrap().owner, owner);
+    assert_eq!(result.get(0).unwrap().weight, 7);
+}
+
+/// The bulk view should also handle the MAX_OWNERS boundary without missing
+/// any owners or changing their weights.
+#[test]
+fn get_owner_weights_returns_all_owners_at_max_capacity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AccordContract, ());
+    let client = AccordContractClient::new(&env, &contract_id);
+
+    let mut owners = Vec::new(&env);
+    let mut weights = Vec::new(&env);
+    for i in 0..MAX_OWNERS {
+        let owner = Address::generate(&env);
+        owners.push_back(owner.clone());
+        weights.push_back((i + 1) as u32);
+    }
+
+    client.initialize(&owners, &weights, &1, &0);
+
+    let result = client.get_owner_weights();
+    assert_eq!(result.len(), MAX_OWNERS as usize);
+    let mut sum: u32 = 0;
+    for entry in result.iter() {
+        sum = sum.checked_add(entry.weight).unwrap();
+    }
+    assert_eq!(sum, client.get_total_weight());
+}
+
 /// After adding and then removing an owner, get_owner_weights must reflect
 /// the current set and the total-weight counter must still match.
 #[test]

--- a/docs/CONTRACT_API.md
+++ b/docs/CONTRACT_API.md
@@ -309,6 +309,16 @@ Returns every current owner's address paired with their voting weight, in a sing
 
 **Errors:** `NotInitialized`
 
+### JavaScript SDK example
+
+```js
+const ownerWeights = await contract.call("get_owner_weights");
+```
+
+In practice, frontends should use this view instead of calling `get_owner_weight` once per owner when they need the full set of weights for a governance overview or owners list.
+
+> Pagination was intentionally deferred for this view because the owner set is capped at 20 (`MAX_OWNERS`), so a single call already returns the entire current owner-weight snapshot without introducing extra complexity.
+
 ---
 
 ## `has_approved`

--- a/frontend/src/components/CreateProposalModal.tsx
+++ b/frontend/src/components/CreateProposalModal.tsx
@@ -10,7 +10,7 @@ import {
 import {
   getOwners,
   getThreshold,
-  getOwnerWeight,
+  getOwnerWeights,
   getTotalWeight,
   getRequiredQuorumWeight,
   getWeightCapPct,
@@ -193,12 +193,14 @@ export function CreateProposalModal({ walletAddress, onClose, onSubmitted, trigg
 
         const weightMap: Record<string, number> = {};
         let computedSum = 0;
-        for (const addr of ownerAddrs) {
-          try {
-            const w = await getOwnerWeight(addr);
-            weightMap[addr] = w;
-            computedSum += w;
-          } catch {
+        try {
+          const ownerWeights = await getOwnerWeights();
+          for (const entry of ownerWeights) {
+            weightMap[entry.address] = entry.weight;
+            computedSum += entry.weight;
+          }
+        } catch {
+          for (const addr of ownerAddrs) {
             weightMap[addr] = 1;
             computedSum += 1;
           }

--- a/frontend/src/hooks/useOwnerWeights.ts
+++ b/frontend/src/hooks/useOwnerWeights.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { getOwnerWeight } from "../lib/contract";
+import { getOwnerWeights } from "../lib/contract";
 
 type OwnerWeightState = {
   weights: Record<string, number>;
@@ -38,10 +38,7 @@ export function useOwnerWeights(ownerAddresses: string[]) {
     async function fetchWeights() {
       setState((s: OwnerWeightState) => ({ ...s, loading: true, error: null }));
       try {
-        const weightPromises = ownerAddresses.map((addr) =>
-          getOwnerWeight(addr).then((w) => ({ address: addr, weight: w }))
-        );
-        const results = await Promise.all(weightPromises);
+        const results = await getOwnerWeights();
         if (cancelled) return;
 
         const weightMap: Record<string, number> = {};

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -189,6 +189,19 @@ export async function getOwnerWeight(owner: string): Promise<number> {
   }
 }
 
+export async function getOwnerWeights(): Promise<Array<{ address: string; weight: number }>> {
+  try {
+    const val = await simulateView("get_owner_weights");
+    const raw = scValToNative(val) as Array<{ owner?: string; address?: string; weight?: number }>;
+    return (raw ?? []).map((entry) => ({
+      address: String(entry.owner ?? entry.address ?? ""),
+      weight: Number(entry.weight ?? 0),
+    }));
+  } catch {
+    return [];
+  }
+}
+
 export async function getTotalWeight(): Promise<number> {
   try {
     const val = await simulateView("get_total_weight");


### PR DESCRIPTION
## Summary

Add a bulk owner-weights view so the frontend can fetch every current owner’s voting weight in a single contract call instead of making one round trip per owner.

## Type of Change

- [x] New feature
- [x] Documentation
- [ ] Bug fix
- [ ] Refactor

## Related Issue

Closes #352

## Testing Checklist

- [ ] Existing tests pass locally
- [x] New tests added to cover this change (where applicable)
- [ ] Manually verified the change works as expected
- [ ] Lint / type checks pass


Closes #352