### PR TITLE
feat: fix issues 492 495 496 497

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,6 +47,7 @@ export default function App() {
   );
   // Ref to return focus to the "+ New" trigger after modal closes (Task 4)
   const newProposalButtonRef = useRef<HTMLButtonElement>(null);
+  const recurringButtonRef = useRef<HTMLButtonElement>(null);
 
   const wallet = useWallet();
   const navigate = useNavigate();
@@ -89,6 +90,15 @@ export default function App() {
     }
     wasShowCreateRef.current = showCreate;
   }, [showCreate]);
+
+  // Return focus to the Recurring trigger when modal transitions from open → closed
+  const wasShowRecurringRef = useRef(false);
+  useEffect(() => {
+    if (!showCreateRecurring && wasShowRecurringRef.current) {
+      recurringButtonRef.current?.focus();
+    }
+    wasShowRecurringRef.current = showCreateRecurring;
+  }, [showCreateRecurring]);
 
   useEffect(() => {
     if (!wallet.address && txPending) {
@@ -447,6 +457,7 @@ export default function App() {
                   onRevoke={handleRevoke}
                   onCreateProposal={() => setShowCreate(true)}
                   onCreateRecurringPayment={() => setShowCreateRecurring(true)}
+                  recurringButtonRef={recurringButtonRef}
                   loading={loading}
                   error={error}
                 />
@@ -514,6 +525,7 @@ export default function App() {
           walletAddress={wallet.address}
           onClose={() => setShowCreateRecurring(false)}
           onSubmitted={refresh}
+          triggerRef={recurringButtonRef}
         />
       )}
     </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,11 +19,13 @@ import { HistoryPage } from "./pages/HistoryPage";
 import { NotFoundPage } from "./pages/NotFoundPage";
 import { OwnersPage } from "./pages/OwnersPage";
 import { ProposalDetailPage } from "./pages/ProposalDetailPage";
+import { RecurringPage } from "./pages/RecurringPage";
 import { SettingsPage } from "./pages/SettingsPage";
 import type { Proposal } from "./types/accord";
 
 const NAV_ITEMS = [
   { label: "dashboard", to: "/app" },
+  { label: "recurring", to: "/app/recurring" },
   { label: "history", to: "/app/history" },
   { label: "owners", to: "/app/owners" },
   { label: "settings", to: "/app/settings" },
@@ -467,6 +469,12 @@ export default function App() {
               path="history"
               element={
                 <HistoryPage proposals={proposals} onApprove={handleApprove} />
+              }
+            />
+            <Route
+              path="recurring"
+              element={
+                <RecurringPage walletAddress={wallet.address} />
               }
             />
             <Route

--- a/frontend/src/components/CreateRecurringPaymentModal.tsx
+++ b/frontend/src/components/CreateRecurringPaymentModal.tsx
@@ -12,10 +12,14 @@ const TOKEN_ADDRESSES: Record<string, string> = {
 
 const CATEGORY_OPTIONS: ProposalCategory[] = ["Payroll", "Grant", "Ops", "Transfer", "Other"];
 
+const FOCUSABLE_SELECTORS =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 type Props = {
   walletAddress: string | null;
   onClose: () => void;
   onSubmitted: () => void;
+  triggerRef?: React.RefObject<HTMLButtonElement | null>;
 };
 
 function truncateAddress(address: string | null) {
@@ -29,7 +33,7 @@ function toUnixSeconds(dateValue: string): bigint | null {
   return BigInt(Math.floor(ts / 1000));
 }
 
-export function CreateRecurringPaymentModal({ walletAddress, onClose, onSubmitted }: Props) {
+export function CreateRecurringPaymentModal({ walletAddress, onClose, onSubmitted, triggerRef }: Props) {
   const [recipient, setRecipient] = useState("");
   const [recipientTouched, setRecipientTouched] = useState(false);
   const [amount, setAmount] = useState("");
@@ -46,26 +50,55 @@ export function CreateRecurringPaymentModal({ walletAddress, onClose, onSubmitte
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const recipientInputRef = useRef<HTMLInputElement>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const firstInputRef = useRef<HTMLInputElement>(null);
 
+  // Focus trap + initial focus + restore on unmount
   useEffect(() => {
     const previousActiveElement = document.activeElement as HTMLElement | null;
-    recipientInputRef.current?.focus();
+    const currentTrigger = triggerRef?.current;
+    if (firstInputRef.current) {
+      firstInputRef.current.focus();
+    }
+
+    const modal = modalRef.current;
+    if (!modal) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
+        e.preventDefault();
         onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const focusable = Array.from(
+        modal.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS),
+      ).filter((el) => !el.closest('[aria-hidden="true"]'));
+
+      if (focusable.length === 0) { e.preventDefault(); return; }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) { e.preventDefault(); last.focus(); }
+      } else {
+        if (document.activeElement === last) { e.preventDefault(); first.focus(); }
       }
     };
-    window.addEventListener("keydown", handleKeyDown);
+
+    modal.addEventListener("keydown", handleKeyDown);
 
     return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-      if (previousActiveElement && typeof previousActiveElement.focus === "function") {
+      modal.removeEventListener("keydown", handleKeyDown);
+      if (currentTrigger && typeof currentTrigger.focus === "function") {
+        currentTrigger.focus();
+      } else if (previousActiveElement && typeof previousActiveElement.focus === "function") {
         previousActiveElement.focus();
       }
     };
-  }, [onClose]);
+  }, [onClose, triggerRef]);
 
   async function handleSubmit() {
     if (!walletAddress) {
@@ -150,20 +183,25 @@ export function CreateRecurringPaymentModal({ walletAddress, onClose, onSubmitte
   }
 
   return (
-    <div
-      onKeyDown={(e) => {
-        if (e.key === "Escape") {
-          onClose();
-        }
-      }}
-      className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4"
-    >
-      <div className="bg-zinc-900 border border-zinc-700 rounded-2xl p-6 w-full max-w-lg">
-        <div className="flex items-center justify-between mb-6">
-          <h2 className="text-white font-semibold text-lg">Create Recurring Payment</h2>
+    <>
+      <div
+        aria-hidden="true"
+        className="fixed inset-0 bg-black/70 backdrop-blur-sm z-50"
+      />
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="recurring-modal-title"
+        className="fixed inset-0 flex items-center justify-center z-50 p-4"
+      >
+        <div className="bg-zinc-900 border border-zinc-700 rounded-2xl p-6 w-full max-w-lg">
+          <div className="flex items-center justify-between mb-6">
+          <h2 id="recurring-modal-title" className="text-white font-semibold text-lg">Create Recurring Payment</h2>
           <button
             type="button"
             onClick={onClose}
+            aria-label="Close modal"
             className="text-zinc-500 hover:text-zinc-300 text-xl focus:ring-2 focus:ring-zinc-400 focus:outline-none rounded-md"
           >
             ✕
@@ -184,10 +222,11 @@ export function CreateRecurringPaymentModal({ walletAddress, onClose, onSubmitte
             </div>
           </div>
 
-          <div>
-            <label className="text-xs text-zinc-400 block mb-1.5">Recipient Address</label>
+           <div>
+            <label htmlFor="recurring-recipient" className="text-xs text-zinc-400 block mb-1.5">Recipient Address</label>
             <input
-              ref={recipientInputRef}
+              id="recurring-recipient"
+              ref={firstInputRef}
               value={recipient}
               onChange={(e) => {
                 setRecipient(e.target.value);
@@ -195,29 +234,34 @@ export function CreateRecurringPaymentModal({ walletAddress, onClose, onSubmitte
               }}
               onBlur={() => setRecipientTouched(true)}
               placeholder="G..."
+              aria-label="Recipient Stellar address"
+              aria-invalid={recipientTouched && !StrKey.isValidEd25519PublicKey(recipient.trim())}
+              aria-describedby={recipientTouched && !StrKey.isValidEd25519PublicKey(recipient.trim()) ? "recurring-recipient-error" : undefined}
               className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm font-mono placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
             />
             {recipientTouched && !StrKey.isValidEd25519PublicKey(recipient.trim()) && (
-              <p className="text-xs text-red-400 mt-1">Enter a valid Stellar address.</p>
+              <p id="recurring-recipient-error" className="text-xs text-red-400 mt-1" role="alert">Enter a valid Stellar address.</p>
             )}
           </div>
 
           <div className="grid gap-3 sm:grid-cols-2">
             <div>
-              <label className="text-xs text-zinc-400 block mb-1.5">Amount</label>
+              <label htmlFor="recurring-amount" className="text-xs text-zinc-400 block mb-1.5">Amount</label>
               <input
+                id="recurring-amount"
                 value={amount}
                 onChange={(e) => setAmount(e.target.value)}
                 placeholder="0.00"
                 type="number"
                 min="0"
                 step="any"
+                aria-label="Payment amount"
                 className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
               />
             </div>
             <div>
               <label className="text-xs text-zinc-400 block mb-1.5">Token</label>
-              <div className="grid grid-cols-3 gap-1">
+              <div className="grid grid-cols-3 gap-1" role="group" aria-label="Select token">
                 {(["XLM", "USDC", "EURC"] as const).map((symbol) => {
                   const active = token === symbol;
                   return (
@@ -226,6 +270,7 @@ export function CreateRecurringPaymentModal({ walletAddress, onClose, onSubmitte
                       type="button"
                       onClick={() => setToken(symbol)}
                       aria-pressed={active}
+                      aria-label={`Select ${symbol} token`}
                       className={`rounded-lg border px-1.5 py-2 text-xs font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none ${
                         active
                           ? "border-emerald-500 bg-emerald-500/20 text-emerald-300"
@@ -242,21 +287,25 @@ export function CreateRecurringPaymentModal({ walletAddress, onClose, onSubmitte
 
           <div className="grid gap-3 sm:grid-cols-2">
             <div>
-              <label className="text-xs text-zinc-400 block mb-1.5">Interval (seconds)</label>
+              <label htmlFor="recurring-interval" className="text-xs text-zinc-400 block mb-1.5">Interval (seconds)</label>
               <input
+                id="recurring-interval"
                 value={interval}
                 onChange={(e) => setInterval(e.target.value)}
                 placeholder="2592000"
                 type="number"
                 min="1"
+                aria-label="Payment interval in seconds"
                 className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
               />
             </div>
             <div>
-              <label className="text-xs text-zinc-400 block mb-1.5">Category</label>
+              <label htmlFor="recurring-category" className="text-xs text-zinc-400 block mb-1.5">Category</label>
               <select
+                id="recurring-category"
                 value={category}
                 onChange={(e) => setCategory(e.target.value as ProposalCategory)}
+                aria-label="Payment category"
                 className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
               >
                 {CATEGORY_OPTIONS.map((option) => (
@@ -270,49 +319,57 @@ export function CreateRecurringPaymentModal({ walletAddress, onClose, onSubmitte
 
           <div className="grid gap-3 sm:grid-cols-3">
             <div>
-              <label className="text-xs text-zinc-400 block mb-1.5">Start</label>
+              <label htmlFor="recurring-start" className="text-xs text-zinc-400 block mb-1.5">Start</label>
               <input
+                id="recurring-start"
                 type="date"
                 value={start}
                 onChange={(e) => setStart(e.target.value)}
+                aria-label="Payment start date"
                 className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
               />
             </div>
             <div>
-              <label className="text-xs text-zinc-400 block mb-1.5">Cliff</label>
+              <label htmlFor="recurring-cliff" className="text-xs text-zinc-400 block mb-1.5">Cliff</label>
               <input
+                id="recurring-cliff"
                 type="date"
                 value={cliff}
                 onChange={(e) => setCliff(e.target.value)}
+                aria-label="Payment cliff date"
                 className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
               />
             </div>
             <div>
-              <label className="text-xs text-zinc-400 block mb-1.5">End</label>
+              <label htmlFor="recurring-end" className="text-xs text-zinc-400 block mb-1.5">End</label>
               <input
+                id="recurring-end"
                 type="date"
                 value={end}
                 onChange={(e) => setEnd(e.target.value)}
+                aria-label="Payment end date"
                 className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
               />
             </div>
           </div>
 
           <div>
-            <label className="text-xs text-zinc-400 block mb-1.5">Cap</label>
+            <label htmlFor="recurring-cap" className="text-xs text-zinc-400 block mb-1.5">Cap</label>
             <input
+              id="recurring-cap"
               value={cap}
               onChange={(e) => setCap(e.target.value)}
               placeholder="Optional total cap"
               type="number"
               min="0"
               step="any"
+              aria-label="Optional payment cap"
               className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-zinc-600 focus:ring-2 focus:ring-zinc-400 focus:outline-none focus:border-zinc-500"
             />
           </div>
 
           {error && (
-            <p className="text-xs text-red-400 bg-red-500/10 rounded-lg px-3 py-2">
+            <p className="text-xs text-red-400 bg-red-500/10 rounded-lg px-3 py-2" role="alert">
               {error}
             </p>
           )}
@@ -325,6 +382,7 @@ export function CreateRecurringPaymentModal({ walletAddress, onClose, onSubmitte
               title={
                 walletAddress ? undefined : "Connect your Freighter wallet to submit"
               }
+              aria-label={submitting ? "Submitting recurring payment" : "Create Recurring Payment"}
               className="w-full bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white py-2.5 rounded-lg font-medium transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
             >
               {submitting ? "Submitting…" : "Create Recurring Payment"}
@@ -332,6 +390,7 @@ export function CreateRecurringPaymentModal({ walletAddress, onClose, onSubmitte
           </div>
         </div>
       </div>
-    </div>
+      </div>
+    </>
   );
 }

--- a/frontend/src/components/RecurringPaymentCard.test.tsx
+++ b/frontend/src/components/RecurringPaymentCard.test.tsx
@@ -77,7 +77,7 @@ describe("RecurringPaymentCard", () => {
   test("due schedule renders enabled Disburse now button", () => {
     renderCard({ isDue: true });
 
-    const disburseBtn = screen.getByRole("button", { name: "Disburse now" });
+    const disburseBtn = screen.getByRole("button", { name: "Disburse schedule 1 now" });
     expect(disburseBtn).toBeDefined();
     expect(disburseBtn).not.toBeDisabled();
     expect(screen.getByText("Payment is due")).toBeDefined();
@@ -86,7 +86,7 @@ describe("RecurringPaymentCard", () => {
   test("calls disburse callback or hook when Disburse now button is clicked", () => {
     renderCard({ isDue: true });
 
-    const disburseBtn = screen.getByRole("button", { name: "Disburse now" });
+    const disburseBtn = screen.getByRole("button", { name: "Disburse schedule 1 now" });
     fireEvent.click(disburseBtn);
 
     expect(mockDisburse).toHaveBeenCalledWith(1);

--- a/frontend/src/components/RecurringPaymentCard.tsx
+++ b/frontend/src/components/RecurringPaymentCard.tsx
@@ -96,7 +96,7 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
     (schedule.interval !== undefined ? formatInterval(schedule.interval) : "—");
 
   return (
-    <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-4 transition-colors hover:border-zinc-700">
+    <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-4 transition-colors hover:border-zinc-700" aria-label={`Recurring payment schedule ${schedule.id}, ${badge.label}, ${schedule.amount} ${schedule.token ?? ""}`}>
       <div className="flex items-start justify-between gap-2 mb-3">
         <div>
           <div className="flex items-center gap-2 mb-1">
@@ -105,6 +105,8 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
             </span>
             <span
               className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium uppercase tracking-wider ${badge.style}`}
+              role="status"
+              aria-label={`Status: ${badge.label}`}
             >
               {badge.label}
             </span>
@@ -141,7 +143,7 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
 
       {/* Action buttons based on status */}
       <div className="flex items-center justify-between border-t border-zinc-800/60 pt-3 mt-3">
-        <div className="text-xs text-zinc-500">
+        <div className="text-xs text-zinc-500" aria-live="polite">
           {schedule.status === "active" &&
             (due ? (
               <span className="text-emerald-400">Payment is due</span>
@@ -159,7 +161,7 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
                   onClick={handleDisburse}
                   disabled={!due}
                   aria-label={
-                    due ? "Disburse now" : "Next disbursement not yet due"
+                    due ? `Disburse schedule ${schedule.id} now` : "Next disbursement not yet due"
                   }
                   className="rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-zinc-400"
                 >
@@ -172,7 +174,7 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
                   <button
                     type="button"
                     onClick={handlePause}
-                    aria-label="Pause schedule"
+                    aria-label={`Pause schedule ${schedule.id}`}
                     className="rounded-lg bg-zinc-800 px-3 py-1.5 text-xs font-medium text-yellow-400 hover:bg-zinc-700 hover:text-yellow-300 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400"
                   >
                     Pause
@@ -180,7 +182,7 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
                   <button
                     type="button"
                     onClick={handleCancel}
-                    aria-label="Cancel schedule"
+                    aria-label={`Cancel schedule ${schedule.id}`}
                     className="rounded-lg bg-zinc-800 px-3 py-1.5 text-xs font-medium text-rose-400 hover:bg-zinc-700 hover:text-rose-300 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400"
                   >
                     Cancel
@@ -195,7 +197,7 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
               <button
                 type="button"
                 onClick={handleResume}
-                aria-label="Resume schedule"
+                aria-label={`Resume schedule ${schedule.id}`}
                 className="rounded-lg bg-yellow-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-yellow-500 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400"
               >
                 Resume
@@ -203,7 +205,7 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
               <button
                 type="button"
                 onClick={handleCancel}
-                aria-label="Cancel schedule"
+                aria-label={`Cancel schedule ${schedule.id}`}
                 className="rounded-lg bg-zinc-800 px-3 py-1.5 text-xs font-medium text-rose-400 hover:bg-zinc-700 hover:text-rose-300 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400"
               >
                 Cancel
@@ -212,13 +214,13 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
           )}
 
           {schedule.status === "completed" && (
-            <span className="text-xs text-zinc-500 italic">
+            <span className="text-xs text-zinc-500 italic" role="status">
               Schedule completed
             </span>
           )}
 
           {schedule.status === "cancelled" && (
-            <span className="text-xs text-zinc-500 italic">
+            <span className="text-xs text-zinc-500 italic" role="status">
               Schedule cancelled
             </span>
           )}

--- a/frontend/src/hooks/useContract.ts
+++ b/frontend/src/hooks/useContract.ts
@@ -7,6 +7,8 @@ import {
   mapProposal,
   hasApproved,
   getApprovers,
+  getRecurringPayments,
+  computeMonthlyOutflow,
 } from "../lib/contract";
 import type { DashboardStat, Owner, Proposal } from "../types/accord";
 
@@ -96,6 +98,17 @@ export function useContract(walletAddress: string | null): ContractState {
         ).length;
         const executed = proposalsWithApproval.filter((p) => p.status === "executed").length;
 
+        let recurringOutflow = "";
+        try {
+          const schedules = await getRecurringPayments();
+          if (!cancelled) {
+            const monthly = computeMonthlyOutflow(schedules);
+            recurringOutflow = monthly > 0 ? `$${monthly.toFixed(2)}` : "$0.00";
+          }
+        } catch {
+          recurringOutflow = "N/A";
+        }
+
         setStats([
           {
             label: "Threshold",
@@ -105,6 +118,7 @@ export function useContract(walletAddress: string | null): ContractState {
           { label: "Active", value: String(active), sub: "proposals" },
           { label: "Total", value: String(total), sub: "proposals created" },
           { label: "Executed", value: String(executed), sub: "all time" },
+          { label: "Recurring Outflows", value: recurringOutflow || "$0.00", sub: "per month" },
         ]);
         
         if (!cancelled) {

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -883,3 +883,29 @@ export async function getDueRecurring(): Promise<RecurringSchedule[]> {
   });
 }
 
+export async function getRecurringPaymentsPaged(
+  offset: number,
+  limit: number
+): Promise<RecurringSchedule[]> {
+  try {
+    const val = await simulateView("get_recurring_payments_paged", [
+      nativeToScVal(BigInt(offset), { type: "u64" }),
+      nativeToScVal(limit, { type: "u32" }),
+    ]);
+    const raw = scValToNative(val);
+    if (!Array.isArray(raw)) return [];
+    return raw.map(mapRecurringSchedule).filter((s): s is RecurringSchedule => s !== null);
+  } catch {
+    return [];
+  }
+}
+
+export async function getTotalRecurringPayments(): Promise<number> {
+  try {
+    const val = await simulateView("get_total_recurring_payments");
+    return Number(scValToNative(val));
+  } catch {
+    return 0;
+  }
+}
+

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -15,6 +15,7 @@ import type {
   ProposalEventType,
   ProposalKind,
   ProposalStatus,
+  RecurringSchedule,
 } from "../types/accord";
 import { stroopsToDisplay, formatDeadline, shortenAddr } from "./soroban";
 
@@ -787,5 +788,88 @@ export async function getProposalEvents(proposalId: number): Promise<ProposalEve
     console.error(`Failed to fetch events for proposal #${proposalId}:`, err);
     throw err;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Recurring payments
+// ---------------------------------------------------------------------------
+
+function mapRecurringSchedule(raw: unknown): RecurringSchedule | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+
+  const id = Number(obj.id ?? obj.schedule_id ?? obj.schedule_number ?? 0);
+  if (!id) return null;
+
+  const rawStatus = String(obj.status ?? "active").toLowerCase();
+  const status: RecurringSchedule["status"] =
+    rawStatus === "paused" || rawStatus === "completed" || rawStatus === "cancelled"
+      ? rawStatus
+      : "active";
+
+  const rawAmount = obj.amount ?? obj.amount_per_period ?? obj.payment_amount ?? 0n;
+  let amountDisplay: string;
+  if (typeof rawAmount === "bigint") {
+    amountDisplay = stroopsToDisplay(rawAmount);
+  } else if (typeof rawAmount === "number") {
+    amountDisplay = rawAmount >= 10_000_000 ? stroopsToDisplay(BigInt(Math.round(rawAmount))) : String(rawAmount);
+  } else {
+    amountDisplay = String(rawAmount);
+  }
+
+  const interval = obj.interval ?? obj.interval_secs ?? obj.cadence_secs;
+  const intervalNum = interval !== undefined ? Number(interval) : undefined;
+
+  const recipient = String(obj.recipient ?? obj.to ?? "");
+  const token = obj.token ? shortenAddr(String(obj.token)) : undefined;
+  const totalDisbursed = obj.total_disbursed !== undefined ? stroopsToDisplay(safeBigInt(obj.total_disbursed)) : "0";
+  const cap = obj.cap !== undefined ? stroopsToDisplay(safeBigInt(obj.cap)) : undefined;
+  const nextDisbursementTs = obj.next_disbursement_ts !== undefined ? Number(safeBigInt(obj.next_disbursement_ts)) * 1000 : undefined;
+  const description = obj.description ? String(obj.description) : undefined;
+  const cliff = obj.cliff !== undefined ? Number(safeBigInt(obj.cliff)) : undefined;
+  const endDate = obj.end_date !== undefined ? Number(safeBigInt(obj.end_date)) : undefined;
+
+  return {
+    id,
+    recipient,
+    amount: amountDisplay,
+    token,
+    cadence: obj.cadence ? String(obj.cadence) : undefined,
+    interval: intervalNum,
+    totalDisbursed,
+    status,
+    cliff,
+    endDate,
+    cap,
+    nextDisbursementTs,
+    description,
+  };
+}
+
+export async function getRecurringPayments(): Promise<RecurringSchedule[]> {
+  try {
+    const val = await simulateView("get_recurring_payments");
+    const raw = scValToNative(val);
+    if (!Array.isArray(raw)) return [];
+    return raw.map(mapRecurringSchedule).filter((s): s is RecurringSchedule => s !== null);
+  } catch {
+    return [];
+  }
+}
+
+const SECONDS_PER_MONTH = 2_629_743;
+
+export function computeMonthlyOutflow(schedules: RecurringSchedule[]): number {
+  let total = 0;
+  for (const s of schedules) {
+    if (s.status !== "active") continue;
+    const amountNum = Number.parseFloat(s.amount);
+    if (!Number.isFinite(amountNum) || amountNum <= 0) continue;
+    const intervalSecs = s.interval ?? 0;
+    if (intervalSecs <= 0) continue;
+    const periodsPerMonth = SECONDS_PER_MONTH / intervalSecs;
+    total += amountNum * periodsPerMonth;
+  }
+  return total;
 }
 

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -873,3 +873,13 @@ export function computeMonthlyOutflow(schedules: RecurringSchedule[]): number {
   return total;
 }
 
+export async function getDueRecurring(): Promise<RecurringSchedule[]> {
+  const schedules = await getRecurringPayments();
+  const now = Date.now();
+  return schedules.filter((s) => {
+    if (s.status !== "active") return false;
+    if (s.nextDisbursementTs !== undefined) return now >= s.nextDisbursementTs;
+    return true;
+  });
+}
+

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -17,6 +17,7 @@ type DashboardPageProps = {
   onRevoke: (id: number) => void;
   onCreateProposal: () => void;
   onCreateRecurringPayment: () => void;
+  recurringButtonRef?: React.RefObject<HTMLButtonElement | null>;
   loading: boolean;
   error: string | null;
 };
@@ -31,6 +32,7 @@ export function DashboardPage({
   onRevoke,
   onCreateProposal,
   onCreateRecurringPayment,
+  recurringButtonRef,
   loading,
   error,
 }: DashboardPageProps) {
@@ -132,9 +134,11 @@ export function DashboardPage({
             New
           </button>
           <button
+            ref={recurringButtonRef}
             type="button"
             onClick={onCreateRecurringPayment}
-            className="inline-flex items-center gap-1.5 text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-300 px-3 py-1.5 rounded-lg transition-colors"
+            aria-label="Create recurring payment"
+            className="inline-flex items-center gap-1.5 text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-300 px-3 py-1.5 rounded-lg transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none"
           >
             <Repeat2 size={14} />
             Recurring

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -77,7 +77,7 @@ export function DashboardPage({
 
   return (
     <>
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 mb-8">
         {dashboardStats.map((s) => (
           <StatCard key={s.label} label={s.label} value={s.value} sub={s.sub} />
         ))}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 import { Plus, Repeat2 } from "lucide-react";
-import type { DashboardStat, Owner, Proposal } from "../types/accord";
+import type { DashboardStat, Owner, Proposal, RecurringSchedule } from "../types/accord";
 import { ProposalCard } from "../components/ProposalCard";
 import { StatCard } from "../components/StatCard";
 import { ProposalCardSkeleton } from "../components/ProposalCardSkeleton";
 import { useOwnerWeights } from "../hooks/useOwnerWeights";
-import { getRequiredQuorumWeight } from "../lib/contract";
+import { getRequiredQuorumWeight, getDueRecurring } from "../lib/contract";
 
 type DashboardPageProps = {
   activeProposals: Proposal[];
@@ -40,6 +40,7 @@ export function DashboardPage({
   const [bannerDismissed, setBannerDismissed] = useState(false);
   const [sortByDeadline, setSortByDeadline] = useState(false);
   const [dismissedError, setDismissedError] = useState<string | null>(null);
+  const [dueSchedules, setDueSchedules] = useState<RecurringSchedule[]>([]);
   const prevReadyCount = useRef(readyCount);
 
   const displayedProposals = [...activeProposals].sort((left, right) => {
@@ -65,6 +66,18 @@ export function DashboardPage({
   }, []);
 
   useEffect(() => {
+    let active = true;
+    getDueRecurring()
+      .then((schedules) => {
+        if (active) setDueSchedules(schedules);
+      })
+      .catch(() => {
+        /* noop */
+      });
+    return () => { active = false; };
+  }, []);
+
+  useEffect(() => {
     if (readyCount > prevReadyCount.current) {
       setBannerDismissed(false);
     }
@@ -82,6 +95,52 @@ export function DashboardPage({
           <StatCard key={s.label} label={s.label} value={s.value} sub={s.sub} />
         ))}
       </div>
+
+      {dueSchedules.length > 0 && (
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4 mb-6">
+          <h3 className="font-semibold text-sm mb-3">
+            Due for disbursement
+            <span className="ml-2 text-xs text-zinc-500 font-normal">
+              {dueSchedules.length} {dueSchedules.length === 1 ? "schedule" : "schedules"}
+            </span>
+          </h3>
+          <div className="space-y-2">
+            {dueSchedules.map((schedule) => (
+              <div
+                key={schedule.id}
+                className="flex items-center justify-between rounded-lg bg-zinc-800/50 px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <span className="text-sm text-white font-medium">
+                    {schedule.amount} {schedule.token ?? ""}
+                  </span>
+                  <span className="text-xs text-zinc-500 ml-2">
+                    Schedule #{schedule.id}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  aria-label={`Disburse schedule ${schedule.id} now`}
+                  className="rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-500 focus:outline-none focus:ring-2 focus:ring-zinc-400 shrink-0 ml-3"
+                >
+                  Disburse now
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {dueSchedules.length === 0 && !loading && (
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4 mb-6">
+          <h3 className="font-semibold text-sm text-zinc-400 mb-1">
+            Due for disbursement
+          </h3>
+          <p className="text-xs text-zinc-600">
+            No schedules are currently due for disbursement.
+          </p>
+        </div>
+      )}
 
       {error && !loading && dismissedError !== error && (
           <div className="bg-red-500/10 border border-red-500/20 rounded-xl px-4 py-3 mb-6 text-sm text-red-400 flex items-center justify-between">

--- a/frontend/src/pages/RecurringPage.tsx
+++ b/frontend/src/pages/RecurringPage.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from "react";
+import type { RecurringSchedule, RecurringScheduleStatus } from "../types/accord";
+import { RecurringPaymentCard } from "../components/RecurringPaymentCard";
+import {
+  getRecurringPaymentsPaged,
+  getTotalRecurringPayments,
+} from "../lib/contract";
+
+type StatusFilter = "all" | RecurringScheduleStatus;
+
+const TABS: { key: StatusFilter; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "active", label: "Active" },
+  { key: "paused", label: "Paused" },
+  { key: "completed", label: "Completed" },
+  { key: "cancelled", label: "Cancelled" },
+];
+
+const PAGE_SIZE = 20;
+
+export function RecurringPage({
+  walletAddress,
+}: {
+  walletAddress?: string | null;
+}) {
+  const [activeTab, setActiveTab] = useState<StatusFilter>("all");
+  const [schedules, setSchedules] = useState<RecurringSchedule[]>([]);
+  const [offset, setOffset] = useState(0);
+  const [totalCount, setTotalCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  useEffect(() => {
+    let cancelled = true;
+    setLoading(true);
+
+    (async () => {
+      try {
+        const total = await getTotalRecurringPayments();
+        if (cancelled) return;
+        setTotalCount(total);
+
+        if (total > 0) {
+          const initial = await getRecurringPaymentsPaged(0, Math.min(total, PAGE_SIZE));
+          if (!cancelled) {
+            setSchedules(initial);
+            setOffset(initial.length);
+          }
+        }
+      } catch {
+        // noop
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, []);
+
+  const hasMore = offset < totalCount;
+
+  const handleLoadMore = async () => {
+    if (loadingMore || !hasMore) return;
+    setLoadingMore(true);
+    try {
+      const next = await getRecurringPaymentsPaged(offset, PAGE_SIZE);
+      setSchedules((prev) => [...prev, ...next]);
+      setOffset((prev) => prev + next.length);
+    } catch {
+      // noop
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  const filtered = activeTab === "all"
+    ? schedules
+    : schedules.filter((s) => s.status === activeTab);
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="font-semibold">Recurring Schedules</h2>
+        <div className="flex items-center gap-1 bg-zinc-900 border border-zinc-800 p-1 rounded-lg">
+          {TABS.map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setActiveTab(tab.key)}
+              aria-label={`Filter by ${tab.label} status`}
+              aria-pressed={activeTab === tab.key}
+              className={`text-xs px-3 py-1 rounded-md capitalize transition-colors focus:ring-2 focus:ring-zinc-400 focus:outline-none ${
+                activeTab === tab.key
+                  ? "bg-zinc-700 text-white"
+                  : "text-zinc-400 hover:text-zinc-200"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {loading ? (
+          <>
+            <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-4 animate-pulse h-32" />
+            <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-4 animate-pulse h-32" />
+          </>
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-16 text-zinc-500 text-sm">
+            <p className="font-semibold mb-2">No schedules found</p>
+            <p>
+              {activeTab === "all"
+                ? "No recurring schedules have been created yet."
+                : `No ${activeTab} schedules found.`}
+            </p>
+          </div>
+        ) : (
+          filtered.map((schedule) => (
+            <RecurringPaymentCard
+              key={schedule.id}
+              schedule={schedule}
+              walletAddress={walletAddress}
+            />
+          ))
+        )}
+      </div>
+
+      {hasMore && (
+        <div className="flex justify-center mt-6">
+          <button
+            type="button"
+            onClick={handleLoadMore}
+            disabled={loadingMore}
+            aria-label="Load more schedules"
+            className="w-full py-3 bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 disabled:opacity-50 disabled:cursor-not-allowed rounded-xl text-sm font-medium text-zinc-300 hover:text-white transition-all flex items-center justify-center gap-2 focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+          >
+            {loadingMore ? (
+              <>
+                <svg className="animate-spin h-4 w-4 text-zinc-400" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                </svg>
+                <span>Loading schedules...</span>
+              </>
+            ) : (
+              "Load More"
+            )}
+          </button>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Closes #496 - 1aa0adc - Accessibility for recurring-payment UI

Focus trap in CreateRecurringPaymentModal matching CreateProposalModal pattern
role="dialog", aria-modal, aria-labelledby on modal
ARIA labels on all inputs, selects, and buttons
aria-pressed on token toggles, role="alert" on errors
aria-live="polite" on schedule status, role="status" on badges
Schedule-specific labels on action buttons (e.g. "Disburse schedule 1 now")
triggerRef for focus restoration on modal close

Closes #492 - c4a160d - Recurring Outflows stat card

getRecurringPayments() + mapRecurringSchedule() in contract.ts
computeMonthlyOutflow() sums monthly equivalent from active schedules
"Recurring Outflows" stat card showing per-month committed amount
Dashboard grid updated to accommodate 5 stat cards

Closes #495 - 7fa67ad - Due for Disbursement widget

getDueRecurring() filters active schedules past their nextDisbursementTs
Widget shows due schedules with amount and "Disburse now" button
Empty state when no schedules are due

Closes #497 - ece5b2d - RecurringPage at /recurring

getRecurringPaymentsPaged() + getTotalRecurringPayments() for pagination
RecurringPage with status filter tabs (All/Active/Paused/Completed/Cancelled)
Load-more pagination following HistoryPage pattern
Route wired at /app/recurring, nav link added