### PR TITLE
feat: resolves frontend issues

### DIFF
--- a/frontend/src/components/RecurringPaymentCard.tsx
+++ b/frontend/src/components/RecurringPaymentCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import type { RecurringSchedule, RecurringScheduleStatus } from "../types/accord";
-import { formatInterval, shortenAddr, formatCountdown } from "../lib/soroban";
+import { formatInterval, shortenAddr, formatCountdown, stroopsToDisplay } from "../lib/soroban";
+import { getClaimableAmount } from "../lib/contract";
 import { useRecurringPayments } from "../hooks/useRecurringPayments";
 import {
   PauseRecurringModal,
@@ -85,6 +86,103 @@ function ProgressBar({ disbursed, cap }: { disbursed: string; cap: string }) {
       <div className="flex justify-between text-xs text-zinc-500 mt-1">
         <span>{disbursed} disbursed</span>
         <span>cap {cap}</span>
+      </div>
+    </div>
+  );
+}
+
+function VestingProgressBar({
+  scheduleId,
+  disbursed,
+  cap,
+}: {
+  scheduleId: number;
+  disbursed: string;
+  cap: string;
+}) {
+  const [claimable, setClaimable] = useState<string>("0");
+
+  useEffect(() => {
+    let cancelled = true;
+    (async () => {
+      try {
+        const raw = await getClaimableAmount(scheduleId);
+        if (!cancelled) setClaimable(stroopsToDisplay(raw));
+      } catch {
+        // silently ignore
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [scheduleId]);
+
+  const parse = (v: string) => {
+    const n = Number.parseFloat(v.replace(/[^0-9.]/g, ""));
+    return Number.isFinite(n) ? n : 0;
+  };
+
+  const claimed = parse(disbursed);
+  const claimableNum = parse(claimable);
+  const total = parse(cap);
+  const unvested = Math.max(0, total - claimed - claimableNum);
+
+  const claimedPct = total > 0 ? Math.min(100, (claimed / total) * 100) : 0;
+  const claimablePct = total > 0 ? Math.min(100 - claimedPct, (claimableNum / total) * 100) : 0;
+  const unvestedPct = Math.max(0, 100 - claimedPct - claimablePct);
+
+  return (
+    <div className="mt-2">
+      <div className="flex justify-between text-xs text-zinc-500 mb-1">
+        <span>Vesting progress</span>
+        <span className="text-zinc-300">{(claimedPct + claimablePct).toFixed(1)}%</span>
+      </div>
+      <div className="h-1.5 rounded-full bg-zinc-800 overflow-hidden flex">
+        {claimedPct > 0 && (
+          <div
+            className="h-full bg-emerald-500 transition-all duration-500"
+            style={{ width: `${claimedPct}%` }}
+            role="progressbar"
+            aria-valuenow={claimedPct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`${claimedPct.toFixed(1)}% claimed`}
+          />
+        )}
+        {claimablePct > 0 && (
+          <div
+            className="h-full bg-sky-500 transition-all duration-500"
+            style={{ width: `${claimablePct}%` }}
+            role="progressbar"
+            aria-valuenow={claimablePct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`${claimablePct.toFixed(1)}% claimable`}
+          />
+        )}
+        {unvestedPct > 0 && (
+          <div
+            className="h-full bg-zinc-600 transition-all duration-500"
+            style={{ width: `${unvestedPct}%` }}
+            role="progressbar"
+            aria-valuenow={unvestedPct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`${unvestedPct.toFixed(1)}% unvested`}
+          />
+        )}
+      </div>
+      <div className="flex justify-between text-xs text-zinc-500 mt-1 gap-2">
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
+          {disbursed} claimed
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-2 h-2 rounded-full bg-sky-500" />
+          {claimable} claimable
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-2 h-2 rounded-full bg-zinc-600" />
+          {cap} total
+        </span>
       </div>
     </div>
   );
@@ -221,7 +319,14 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
       )}
 
       {/* Progress bar toward cap */}
-      {schedule.cap && (
+      {schedule.cap && schedule.kind === "linear_vesting" && (
+        <VestingProgressBar
+          scheduleId={schedule.id}
+          disbursed={schedule.totalDisbursed}
+          cap={schedule.cap}
+        />
+      )}
+      {schedule.cap && schedule.kind !== "linear_vesting" && (
         <ProgressBar disbursed={schedule.totalDisbursed} cap={schedule.cap} />
       )}
 

--- a/frontend/src/components/RecurringPaymentCard.tsx
+++ b/frontend/src/components/RecurringPaymentCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import type { RecurringSchedule, RecurringScheduleStatus } from "../types/accord";
-import { formatInterval, shortenAddr } from "../lib/soroban";
+import { formatInterval, shortenAddr, formatCountdown } from "../lib/soroban";
 import { useRecurringPayments } from "../hooks/useRecurringPayments";
 import {
   PauseRecurringModal,
@@ -40,17 +40,6 @@ const STATUS_BADGES: Record<RecurringScheduleStatus, { label: string; style: str
   },
 };
 
-function formatCountdown(msUntil: number): string {
-  if (msUntil <= 0) return "Due now";
-  const totalSecs = Math.floor(msUntil / 1000);
-  const days = Math.floor(totalSecs / 86400);
-  const hours = Math.floor((totalSecs % 86400) / 3600);
-  const mins = Math.floor((totalSecs % 3600) / 60);
-  if (days > 0) return `${days}d ${hours}h`;
-  if (hours > 0) return `${hours}h ${mins}m`;
-  return `${mins}m`;
-}
-
 function CountdownTicker({ targetMs }: { targetMs: number }) {
   const [now, setNow] = useState(() => Date.now());
 
@@ -62,7 +51,7 @@ function CountdownTicker({ targetMs }: { targetMs: number }) {
   const diff = targetMs - now;
   return (
     <span className={diff <= 0 ? "text-emerald-400" : "text-zinc-300"}>
-      {formatCountdown(diff)}
+      {formatCountdown(targetMs)}
     </span>
   );
 }
@@ -179,14 +168,22 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
     schedule.cadence ??
     (schedule.interval !== undefined ? formatInterval(schedule.interval) : "—");
 
+  const disburseTooltip = due
+    ? undefined
+    : schedule.nextDisbursementTs !== undefined
+    ? `Next disbursement ${formatCountdown(schedule.nextDisbursementTs)}`
+    : "Next disbursement not yet due";
+
   return (
-    <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-4 transition-colors hover:border-zinc-700" aria-label={`Recurring payment schedule ${schedule.id}, ${badge.label}, ${schedule.amount} ${schedule.token ?? ""}`}>
+    <div
+      className="rounded-xl border border-zinc-800 bg-zinc-900 p-4 transition-colors hover:border-zinc-700"
+      aria-label={`Recurring payment schedule ${schedule.id}, ${badge.label}, ${schedule.amount} ${schedule.token ?? ""}`}
+    >
+      {/* Header row */}
       <div className="flex items-start justify-between gap-2 mb-3">
         <div>
           <div className="flex items-center gap-2 mb-1">
-            <span className="font-mono text-xs text-zinc-500">
-              Schedule #{schedule.id}
-            </span>
+            <span className="font-mono text-xs text-zinc-500">Schedule #{schedule.id}</span>
             <span
               className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium uppercase tracking-wider ${badge.style}`}
               role="status"
@@ -196,57 +193,39 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
             </span>
           </div>
           <h3 className="text-base font-semibold text-white">
-            {schedule.amount} {schedule.token ? schedule.token : ""}
+            {schedule.amount} {schedule.token ?? ""}
           </h3>
           <p className="font-mono text-sm text-zinc-400 mt-0.5">
             Recipient: {shortenAddr(schedule.recipient)}
           </p>
         </div>
 
-        <div className="text-right text-xs text-zinc-500 space-y-1">
-    <>
-      <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-4 transition-colors hover:border-zinc-700">
-        {/* Header row */}
-        <div className="flex items-start justify-between gap-2 mb-3">
+        <div className="text-right text-xs text-zinc-500 space-y-1 shrink-0">
           <div>
-            <div className="flex items-center gap-2 mb-1">
-              <span className="font-mono text-xs text-zinc-500">Schedule #{schedule.id}</span>
-              <span
-                className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium uppercase tracking-wider ${badge.style}`}
-              >
-                {badge.label}
-              </span>
-            </div>
-            <h3 className="text-base font-semibold text-white">
-              {schedule.amount} {schedule.token ?? ""}
-            </h3>
-            <p className="font-mono text-sm text-zinc-400 mt-0.5">
-              Recipient: {shortenAddr(schedule.recipient)}
-            </p>
+            Cadence: <span className="text-zinc-300">{cadenceText}</span>
           </div>
-
-          <div className="text-right text-xs text-zinc-500 space-y-1 shrink-0">
-            <div>
-              Cadence: <span className="text-zinc-300">{cadenceText}</span>
-            </div>
-            <div>
-              Disbursed: <span className="text-zinc-300">{schedule.totalDisbursed}</span>
-            </div>
-            {schedule.nextDisbursementTs !== undefined && schedule.status === "active" && (
-              <div>
-                Next:{" "}
-                <CountdownTicker targetMs={schedule.nextDisbursementTs} />
-              </div>
-            )}
+          <div>
+            Disbursed: <span className="text-zinc-300">{schedule.totalDisbursed}</span>
           </div>
+          {schedule.nextDisbursementTs !== undefined && schedule.status === "active" && (
+            <div>
+              Next: <CountdownTicker targetMs={schedule.nextDisbursementTs} />
+            </div>
+          )}
         </div>
+      </div>
 
-        {/* Description */}
-        {schedule.description && (
-          <p className="text-xs text-zinc-500 mb-3 leading-relaxed">{schedule.description}</p>
-        )}
+      {/* Description */}
+      {schedule.description && (
+        <p className="text-xs text-zinc-500 mb-3 leading-relaxed">{schedule.description}</p>
+      )}
 
-      {/* Action buttons based on status */}
+      {/* Progress bar toward cap */}
+      {schedule.cap && (
+        <ProgressBar disbursed={schedule.totalDisbursed} cap={schedule.cap} />
+      )}
+
+      {/* Footer: status label + action buttons */}
       <div className="flex items-center justify-between border-t border-zinc-800/60 pt-3 mt-3">
         <div className="text-xs text-zinc-500" aria-live="polite">
           {schedule.status === "active" &&
@@ -257,10 +236,10 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
             ))}
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap justify-end">
           {schedule.status === "active" && (
             <>
-              <div title={due ? undefined : "Next disbursement not yet due"}>
+              <div title={disburseTooltip}>
                 <button
                   type="button"
                   onClick={handleDisburse}
@@ -273,88 +252,29 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
                   Disburse now
                 </button>
               </div>
-        {/* Progress bar toward cap */}
-        {schedule.cap && (
-          <ProgressBar disbursed={schedule.totalDisbursed} cap={schedule.cap} />
-        )}
 
-        {/* Footer: status label + action buttons */}
-        <div className="flex items-center justify-between border-t border-zinc-800/60 pt-3 mt-3">
-          <div className="text-xs text-zinc-500">
-            {schedule.status === "active" &&
-              (due ? (
-                <span className="text-emerald-400">Payment is due</span>
-              ) : (
-                <span className="text-zinc-400">Next payment pending</span>
-              ))}
-          </div>
-
-          <div className="flex items-center gap-2 flex-wrap justify-end">
-            {schedule.status === "active" && (
-              <>
-                <div title={due ? undefined : "Next disbursement not yet due"}>
+              {connected && (
+                <>
                   <button
                     type="button"
-                    onClick={handleDisburse}
-                    disabled={!due}
-                    aria-label={due ? "Disburse now" : "Next disbursement not yet due"}
-                    className="rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-zinc-400"
+                    onClick={handleModify}
+                    aria-label="Modify schedule"
+                    className="rounded-lg bg-zinc-800 px-3 py-1.5 text-xs font-medium text-sky-400 hover:bg-zinc-700 hover:text-sky-300 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400"
                   >
-                    Disburse now
+                    Modify
                   </button>
-                </div>
-
-                {connected && (
-                  <>
-                    <button
-                      type="button"
-                      onClick={handleModify}
-                      aria-label="Modify schedule"
-                      className="rounded-lg bg-zinc-800 px-3 py-1.5 text-xs font-medium text-sky-400 hover:bg-zinc-700 hover:text-sky-300 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400"
-                    >
-                      Modify
-                    </button>
-                    <button
-                      type="button"
-                      onClick={handlePause}
-                      aria-label="Pause schedule"
-                      className="rounded-lg bg-zinc-800 px-3 py-1.5 text-xs font-medium text-yellow-400 hover:bg-zinc-700 hover:text-yellow-300 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400"
-                    >
-                      Pause
-                    </button>
-                    <button
-                      type="button"
-                      onClick={handleCancel}
-                      aria-label="Cancel schedule"
-                      className="rounded-lg bg-zinc-800 px-3 py-1.5 text-xs font-medium text-rose-400 hover:bg-zinc-700 hover:text-rose-300 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400"
-                    >
-                      Cancel
-                    </button>
-                  </>
-                )}
-              </>
-            )}
-
-            {schedule.status === "paused" && (
-              <>
-                {connected && (
                   <button
                     type="button"
                     onClick={handlePause}
-                    aria-label={`Pause schedule ${schedule.id}`}
+                    aria-label="Pause schedule"
                     className="rounded-lg bg-zinc-800 px-3 py-1.5 text-xs font-medium text-yellow-400 hover:bg-zinc-700 hover:text-yellow-300 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400"
-                    onClick={handleResume}
-                    aria-label="Resume schedule"
-                    className="rounded-lg bg-yellow-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-yellow-500 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400"
                   >
-                    Resume
+                    Pause
                   </button>
-                )}
-                {connected && (
                   <button
                     type="button"
                     onClick={handleCancel}
-                    aria-label={`Cancel schedule ${schedule.id}`}
+                    aria-label="Cancel schedule"
                     className="rounded-lg bg-zinc-800 px-3 py-1.5 text-xs font-medium text-rose-400 hover:bg-zinc-700 hover:text-rose-300 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400"
                   >
                     Cancel
@@ -374,14 +294,16 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
               >
                 Resume
               </button>
-              <button
-                type="button"
-                onClick={handleCancel}
-                aria-label={`Cancel schedule ${schedule.id}`}
-                className="rounded-lg bg-zinc-800 px-3 py-1.5 text-xs font-medium text-rose-400 hover:bg-zinc-700 hover:text-rose-300 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400"
-              >
-                Cancel
-              </button>
+              {connected && (
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  aria-label={`Cancel schedule ${schedule.id}`}
+                  className="rounded-lg bg-zinc-800 px-3 py-1.5 text-xs font-medium text-rose-400 hover:bg-zinc-700 hover:text-rose-300 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400"
+                >
+                  Cancel
+                </button>
+              )}
             </>
           )}
 
@@ -396,22 +318,10 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
               Schedule cancelled
             </span>
           )}
-                )}
-              </>
-            )}
-
-            {schedule.status === "completed" && (
-              <span className="text-xs text-zinc-500 italic">Schedule completed</span>
-            )}
-
-            {schedule.status === "cancelled" && (
-              <span className="text-xs text-zinc-500 italic">Schedule cancelled</span>
-            )}
-          </div>
         </div>
       </div>
 
-      {/* Governance-proposal modals — rendered outside the card so z-index stacks correctly */}
+      {/* Governance-proposal modals */}
       {activeModal === "pause" && connected && (
         <PauseRecurringModal
           scheduleId={schedule.id}
@@ -446,6 +356,6 @@ export const RecurringPaymentCard = React.memo(function RecurringPaymentCard({
           onSubmitted={handleModalSubmitted}
         />
       )}
-    </>
+    </div>
   );
 });

--- a/frontend/src/lib/__tests__/soroban.test.ts
+++ b/frontend/src/lib/__tests__/soroban.test.ts
@@ -7,6 +7,8 @@ import {
   contractErrorMessage,
   formatDeadline,
   shortenAddr,
+  formatInterval,
+  formatCountdown,
 } from "../soroban";
 
 describe("stroopsToDisplay", () => {
@@ -150,5 +152,82 @@ describe("shortenAddr", () => {
     const addr = "GBTEST12345678901234567890123456789012345678901234WXYZ";
     const result = shortenAddr(addr);
     expect(result).toMatch(/^.{6}\.\.\..{4}$/);
+  });
+});
+
+describe("formatInterval", () => {
+  test("returns 'Daily' for 86400 seconds", () => {
+    expect(formatInterval(86400)).toBe("Daily");
+  });
+
+  test("returns 'Weekly' for 604800 seconds", () => {
+    expect(formatInterval(604800)).toBe("Weekly");
+  });
+
+  test("returns 'Monthly' for 2592000 seconds", () => {
+    expect(formatInterval(2592000)).toBe("Monthly");
+  });
+
+  test("returns 'Yearly' for 31536000 seconds", () => {
+    expect(formatInterval(31536000)).toBe("Yearly");
+  });
+
+  test("returns 'Every N days' for day multiples", () => {
+    expect(formatInterval(172800)).toBe("Every 2 days");
+  });
+
+  test("returns 'Every N hours' for hour multiples", () => {
+    expect(formatInterval(7200)).toBe("Every 2 hours");
+  });
+
+  test("returns 'Every N mins' for minute multiples", () => {
+    expect(formatInterval(180)).toBe("Every 3 mins");
+  });
+
+  test("returns 'Every Ns' for sub-minute intervals", () => {
+    expect(formatInterval(45)).toBe("Every 45s");
+  });
+
+  test("returns dash for zero or negative", () => {
+    expect(formatInterval(0)).toBe("—");
+    expect(formatInterval(-5)).toBe("—");
+  });
+
+  test("handles bigint input", () => {
+    expect(formatInterval(86400n)).toBe("Daily");
+  });
+
+  test("handles string input", () => {
+    expect(formatInterval("604800")).toBe("Weekly");
+  });
+});
+
+describe("formatCountdown", () => {
+  test("returns 'Due now' for past timestamps", () => {
+    expect(formatCountdown(Date.now() - 1000)).toBe("Due now");
+  });
+
+  test("returns 'Due now' for exactly now", () => {
+    expect(formatCountdown(Date.now())).toBe("Due now");
+  });
+
+  test("returns days and hours for far future", () => {
+    const target = Date.now() + 4 * 86400 * 1000 + 3 * 3600 * 1000;
+    expect(formatCountdown(target)).toMatch(/^next in 4d 3h$/);
+  });
+
+  test("returns hours and minutes for hours ahead", () => {
+    const target = Date.now() + 2 * 3600 * 1000 + 30 * 60 * 1000;
+    expect(formatCountdown(target)).toMatch(/^next in 2h 30m$/);
+  });
+
+  test("returns minutes for minutes ahead", () => {
+    const target = Date.now() + 15 * 60 * 1000;
+    expect(formatCountdown(target)).toMatch(/^next in 15m$/);
+  });
+
+  test("returns '<1m' for less than a minute", () => {
+    const target = Date.now() + 30 * 1000;
+    expect(formatCountdown(target)).toBe("next in <1m");
   });
 });

--- a/frontend/src/lib/contract.ts
+++ b/frontend/src/lib/contract.ts
@@ -1001,6 +1001,20 @@ function mapRecurringSchedule(raw: any): RecurringSchedule {
   const capRaw = raw.cap ?? (raw.total_cap != null && Number(safeBigInt(raw.total_cap)) > 0 ? raw.total_cap : null);
   const cap = capRaw != null ? stroopsToDisplay(safeBigInt(capRaw)) : undefined;
 
+  const rawKind = raw.kind ?? raw.payment_kind;
+  let kind: RecurringKind | undefined;
+  if (rawKind !== undefined) {
+    let key: string;
+    if (typeof rawKind === "string") {
+      key = rawKind;
+    } else if (rawKind && typeof rawKind === "object") {
+      key = Object.keys(rawKind as object)[0] ?? "FixedAmountPerPeriod";
+    } else {
+      key = "FixedAmountPerPeriod";
+    }
+    kind = key.toLowerCase() === "linearvesting" ? "linear_vesting" : "fixed_amount_per_period";
+  }
+
   // Compute next disbursement timestamp (ms) for countdown display.
   const lastDisbursedAt = Number(safeBigInt(raw.last_disbursed_at ?? 0));
   const periodsDisbursed = Number(raw.periods_disbursed ?? 0);
@@ -1031,6 +1045,7 @@ function mapRecurringSchedule(raw: any): RecurringSchedule {
     interval: intervalSecs > 0 ? intervalSecs : undefined,
     totalDisbursed,
     status: mapRecurringStatus(raw.status),
+    kind,
     cliff:
       raw.cliff != null && Number(safeBigInt(raw.cliff)) > 0
         ? Number(safeBigInt(raw.cliff))

--- a/frontend/src/lib/soroban.ts
+++ b/frontend/src/lib/soroban.ts
@@ -89,7 +89,7 @@ export function formatInterval(seconds: number | bigint | string): string {
   if (isNaN(s) || s <= 0) return "—";
   if (s === 86400) return "Daily";
   if (s === 604800) return "Weekly";
-  if (s === 2592000 || s === 2629743 || s === 2629800 || s === 2592000) return "Monthly";
+  if (s === 2592000 || s === 2629743 || s === 2629800) return "Monthly";
   if (s === 31536000) return "Yearly";
   if (s % 86400 === 0) {
     const days = s / 86400;
@@ -104,5 +104,18 @@ export function formatInterval(seconds: number | bigint | string): string {
     return mins === 1 ? "1 min" : `Every ${mins} mins`;
   }
   return `Every ${s}s`;
+}
+
+export function formatCountdown(targetMs: number): string {
+  const diff = targetMs - Date.now();
+  if (diff <= 0) return "Due now";
+  const totalSecs = Math.floor(diff / 1000);
+  const days = Math.floor(totalSecs / 86400);
+  const hours = Math.floor((totalSecs % 86400) / 3600);
+  const mins = Math.floor((totalSecs % 3600) / 60);
+  if (days > 0) return `next in ${days}d ${hours}h`;
+  if (hours > 0) return `next in ${hours}h ${mins}m`;
+  if (mins > 0) return `next in ${mins}m`;
+  return "next in <1m";
 }
 

--- a/frontend/src/pages/RecurringPage.tsx
+++ b/frontend/src/pages/RecurringPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import type { RecurringSchedule, RecurringScheduleStatus } from "../types/accord";
 import { RecurringPaymentCard } from "../components/RecurringPaymentCard";
 import {
@@ -17,6 +17,89 @@ const TABS: { key: StatusFilter; label: string }[] = [
 ];
 
 const PAGE_SIZE = 20;
+const TIMELINE_HORIZON_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+
+type TimelineEntry = {
+  date: Date;
+  dateLabel: string;
+  scheduleId: number;
+  amount: string;
+  token?: string;
+  recipient: string;
+};
+
+function buildTimeline(schedules: RecurringSchedule[]): TimelineEntry[] {
+  const now = Date.now();
+  const horizon = now + TIMELINE_HORIZON_MS;
+  const entries: TimelineEntry[] = [];
+
+  for (const s of schedules) {
+    if (s.status !== "active") continue;
+    if (s.nextDisbursementTs === undefined || s.interval === undefined) continue;
+
+    let ts = s.nextDisbursementTs;
+    while (ts <= horizon) {
+      if (ts >= now) {
+        const d = new Date(ts);
+        entries.push({
+          date: d,
+          dateLabel: d.toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+          }),
+          scheduleId: s.id,
+          amount: s.amount,
+          token: s.token,
+          recipient: s.recipient,
+        });
+      }
+      ts += s.interval * 1000;
+    }
+  }
+
+  entries.sort((a, b) => a.date.getTime() - b.date.getTime());
+  return entries;
+}
+
+function DisbursementTimeline({ schedules }: { schedules: RecurringSchedule[] }) {
+  const entries = useMemo(() => buildTimeline(schedules), [schedules]);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-4 mb-4">
+      <h3 className="text-sm font-semibold text-zinc-300 mb-3">Upcoming Disbursements</h3>
+      <div className="relative">
+        <div className="absolute left-3 top-0 bottom-0 w-px bg-zinc-800" />
+        <div className="space-y-3">
+          {entries.slice(0, 20).map((entry, i) => (
+            <div key={`${entry.scheduleId}-${i}`} className="flex items-start gap-3 pl-1">
+              <div className="relative z-10 mt-1.5">
+                <div className="h-2 w-2 rounded-full bg-emerald-500" />
+              </div>
+              <div className="flex-1 min-w-0 flex items-center justify-between gap-2">
+                <div className="min-w-0">
+                  <span className="text-xs text-zinc-400">{entry.dateLabel}</span>
+                  <span className="text-xs text-zinc-600 mx-1.5">·</span>
+                  <span className="text-xs text-zinc-500">Schedule #{entry.scheduleId}</span>
+                </div>
+                <div className="text-xs text-zinc-300 shrink-0">
+                  {entry.amount} {entry.token ?? ""}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+        {entries.length > 20 && (
+          <p className="text-xs text-zinc-600 mt-2 pl-6">
+            + {entries.length - 20} more upcoming disbursements
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
 
 export function RecurringPage({
   walletAddress,
@@ -77,6 +160,8 @@ export function RecurringPage({
     ? schedules
     : schedules.filter((s) => s.status === activeTab);
 
+  const activeSchedules = schedules.filter((s) => s.status === "active");
+
   return (
     <>
       <div className="flex items-center justify-between mb-4">
@@ -100,6 +185,10 @@ export function RecurringPage({
           ))}
         </div>
       </div>
+
+      {!loading && activeSchedules.length > 0 && (
+        <DisbursementTimeline schedules={activeSchedules} />
+      )}
 
       <div className="space-y-3">
         {loading ? (

--- a/frontend/src/types/accord.ts
+++ b/frontend/src/types/accord.ts
@@ -107,6 +107,7 @@ export type RecurringSchedule = {
   interval?: number;
   totalDisbursed: string;
   status: RecurringScheduleStatus;
+  kind?: RecurringKind;
   cliff?: number | string;
   endDate?: number | string;
   cap?: string;


### PR DESCRIPTION
Closes #490 — Added formatCountdown(targetMs) helper to soroban.ts with unit tests in soroban.test.ts. Converts future timestamps to "next in 4d 3h" format, handles due/past timestamps.

Closes #491 — Cleaned up severely duplicated JSX in RecurringPaymentCard.tsx. "Disburse now" button uses formatCountdown in a title tooltip when disabled, showing "Next disbursement next in 4d 3h".

Closes #493 — Added DisbursementTimeline component to RecurringPage.tsx. Computes upcoming disbursement dates from nextDisbursementTs + interval across all active schedules, limited to 90-day horizon, displayed as a vertical timeline with date, schedule ID, and amount.

Closes #494 — Added VestingProgressBar component for linear_vesting schedules. Fetches live claimable amount via getClaimableAmount, renders a three-segment bar: emerald (claimed), sky (claimable), zinc (unvested). Falls back to simple ProgressBar for fixed-amount schedules. Added kind field to RecurringSchedule type and mapping functions.