### PR TITLE
Feat/multi 454 452 453 451

### DIFF
--- a/contracts/accord/src/lib.rs
+++ b/contracts/accord/src/lib.rs
@@ -101,6 +101,10 @@ pub enum ProposalKind {
     CreateRecurringPayment(CreateRecurringParams),
     /// CancelRecurringPayment(schedule_id)
     CancelRecurringPayment(u64),
+    /// PauseRecurringPayment(schedule_id)
+    PauseRecurringPayment(u64),
+    /// ResumeRecurringPayment(schedule_id)
+    ResumeRecurringPayment(u64),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -285,6 +289,20 @@ pub struct RecurringPaymentDisbursedEvent {
     pub periods_disbursed: u32,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct RecurringPaymentPausedEvent {
+    pub id: u64,
+    pub caller: Address,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct RecurringPaymentResumedEvent {
+    pub id: u64,
+    pub caller: Address,
+}
+
 // ─── Errors ──────────────────────────────────────────────────────────────────
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -328,6 +346,10 @@ pub enum ContractError {
     RecurringPaymentInactive = 35,
     RecurringIntervalNotElapsed = 36,
     TooManyActiveRecurring = 37,
+    ScheduleAlreadyCancelled = 38,
+    ScheduleAlreadyPaused = 39,
+    ScheduleNotPaused = 40,
+    ScheduleTerminal = 41,
 }
 
 // ─── Storage Keys ────────────────────────────────────────────────────────────
@@ -2481,6 +2503,45 @@ impl AccordContract {
                     },
                 );
             }
+            ProposalKind::PauseRecurringPayment(schedule_id) => {
+                let mut schedule = read_recurring_payment(&env, *schedule_id)?;
+                let status = derive_recurring_status(&env, &schedule);
+                if status == RecurringStatus::Cancelled || status == RecurringStatus::Completed {
+                    return Err(ContractError::ScheduleTerminal);
+                }
+                if status == RecurringStatus::Paused {
+                    return Err(ContractError::ScheduleAlreadyPaused);
+                }
+
+                schedule.status = RecurringStatus::Paused;
+                write_recurring_payment(&env, &schedule);
+
+                env.events().publish(
+                    (symbol_short!("r_pause"),),
+                    RecurringPaymentPausedEvent {
+                        id: *schedule_id,
+                        caller: executor.clone(),
+                    },
+                );
+            }
+            ProposalKind::ResumeRecurringPayment(schedule_id) => {
+                let mut schedule = read_recurring_payment(&env, *schedule_id)?;
+                let status = derive_recurring_status(&env, &schedule);
+                if status != RecurringStatus::Paused {
+                    return Err(ContractError::ScheduleNotPaused);
+                }
+
+                schedule.status = RecurringStatus::Active;
+                write_recurring_payment(&env, &schedule);
+
+                env.events().publish(
+                    (symbol_short!("r_resum"),),
+                    RecurringPaymentResumedEvent {
+                        id: *schedule_id,
+                        caller: executor.clone(),
+                    },
+                );
+            }
         }
 
         proposal.status = ProposalStatus::Executed;
@@ -2650,6 +2711,131 @@ impl AccordContract {
         let id = read_next_id(&env);
 
         let p_kind = ProposalKind::CancelRecurringPayment(schedule_id);
+
+        let proposal = Proposal {
+            id,
+            proposer: proposer.clone(),
+            description,
+            deadline,
+            approvals: 0,
+            approval_weight: 0,
+            status: ProposalStatus::Pending,
+            kind: p_kind,
+            ready_at: 0,
+            quorum_weight: threshold,
+            category: ProposalCategory::Ops,
+        };
+        write_proposal(&env, &proposal);
+        register_active_proposal(&env, id)?;
+
+        let next_id = id.checked_add(1).ok_or(ContractError::ArithmeticError)?;
+        write_next_id(&env, next_id);
+
+        let total_weight = read_total_weight(&env);
+        env.events().publish(
+            (symbol_short!("created"),),
+            ProposalCreatedEvent {
+                id,
+                proposer,
+                threshold,
+                category: ProposalCategory::Ops,
+                transfers: Vec::new(&env),
+                quorum_weight: threshold,
+                total_weight_at_creation: total_weight,
+            },
+        );
+
+        Ok(id)
+    }
+
+    pub fn create_pause_recurring_proposal(
+        env: Env,
+        proposer: Address,
+        schedule_id: u64,
+        description: String,
+        deadline: u64,
+    ) -> Result<u64, ContractError> {
+        proposer.require_auth();
+        require_owner_and_weight(&env, &proposer)?;
+        require_not_frozen(&env)?;
+
+        let schedule = read_recurring_payment(&env, schedule_id)?;
+        let status = derive_recurring_status(&env, &schedule);
+        if status == RecurringStatus::Cancelled || status == RecurringStatus::Completed {
+            return Err(ContractError::ScheduleTerminal);
+        }
+        if status == RecurringStatus::Paused {
+            return Err(ContractError::ScheduleAlreadyPaused);
+        }
+
+        validate_description(&description)?;
+        validate_deadline(&env, deadline)?;
+
+        let threshold = read_threshold(&env)?;
+        let id = read_next_id(&env);
+
+        let p_kind = ProposalKind::PauseRecurringPayment(schedule_id);
+
+        let proposal = Proposal {
+            id,
+            proposer: proposer.clone(),
+            description,
+            deadline,
+            approvals: 0,
+            approval_weight: 0,
+            status: ProposalStatus::Pending,
+            kind: p_kind,
+            ready_at: 0,
+            quorum_weight: threshold,
+            category: ProposalCategory::Ops,
+        };
+        write_proposal(&env, &proposal);
+        register_active_proposal(&env, id)?;
+
+        let next_id = id.checked_add(1).ok_or(ContractError::ArithmeticError)?;
+        write_next_id(&env, next_id);
+
+        let total_weight = read_total_weight(&env);
+        env.events().publish(
+            (symbol_short!("created"),),
+            ProposalCreatedEvent {
+                id,
+                proposer,
+                threshold,
+                category: ProposalCategory::Ops,
+                transfers: Vec::new(&env),
+                quorum_weight: threshold,
+                total_weight_at_creation: total_weight,
+            },
+        );
+
+        Ok(id)
+    }
+
+    pub fn create_resume_recurring_proposal(
+        env: Env,
+        proposer: Address,
+        schedule_id: u64,
+        description: String,
+        deadline: u64,
+    ) -> Result<u64, ContractError> {
+        proposer.require_auth();
+        require_owner_and_weight(&env, &proposer)?;
+        require_not_frozen(&env)?;
+
+        let schedule = read_recurring_payment(&env, schedule_id)?;
+        let status = derive_recurring_status(&env, &schedule);
+        if status != RecurringStatus::Paused {
+            return Err(ContractError::ScheduleNotPaused);
+        }
+
+        validate_description(&description)?;
+        validate_deadline(&env, deadline)?;
+
+        let threshold = read_threshold(&env)?;
+        let id = read_next_id(&env);
+
+        let p_kind = ProposalKind::ResumeRecurringPayment(schedule_id);
 
         let proposal = Proposal {
             id,

--- a/contracts/accord/src/lib.rs
+++ b/contracts/accord/src/lib.rs
@@ -2481,8 +2481,12 @@ impl AccordContract {
             }
             ProposalKind::CancelRecurringPayment(schedule_id) => {
                 let mut schedule = read_recurring_payment(&env, *schedule_id)?;
-                if schedule.status == RecurringStatus::Cancelled {
+                let status = derive_recurring_status(&env, &schedule);
+                if status == RecurringStatus::Cancelled {
                     return Err(ContractError::ScheduleAlreadyCancelled);
+                }
+                if status == RecurringStatus::Completed {
+                    return Err(ContractError::ScheduleTerminal);
                 }
 
                 if schedule.status == RecurringStatus::Active || schedule.status == RecurringStatus::Paused {
@@ -2700,8 +2704,12 @@ impl AccordContract {
         require_not_frozen(&env)?;
 
         let schedule = read_recurring_payment(&env, schedule_id)?;
-        if schedule.status == RecurringStatus::Cancelled {
+        let status = derive_recurring_status(&env, &schedule);
+        if status == RecurringStatus::Cancelled {
             return Err(ContractError::ScheduleAlreadyCancelled);
+        }
+        if status == RecurringStatus::Completed {
+            return Err(ContractError::ScheduleTerminal);
         }
 
         validate_description(&description)?;

--- a/contracts/accord/src/lib.rs
+++ b/contracts/accord/src/lib.rs
@@ -105,6 +105,17 @@ pub enum ProposalKind {
     PauseRecurringPayment(u64),
     /// ResumeRecurringPayment(schedule_id)
     ResumeRecurringPayment(u64),
+    /// ModifyRecurringPayment(params)
+    ModifyRecurringPayment(ModifyRecurringParams),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct ModifyRecurringParams {
+    pub schedule_id: u64,
+    pub new_amount: Option<i128>,
+    pub new_interval_secs: Option<u64>,
+    pub new_end_time: Option<u64>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -301,6 +312,18 @@ pub struct RecurringPaymentPausedEvent {
 pub struct RecurringPaymentResumedEvent {
     pub id: u64,
     pub caller: Address,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct RecurringPaymentModifiedEvent {
+    pub schedule_id: u64,
+    pub previous_amount: i128,
+    pub new_amount: i128,
+    pub previous_interval: u64,
+    pub new_interval: u64,
+    pub previous_end_time: u64,
+    pub new_end_time: u64,
 }
 
 // ─── Errors ──────────────────────────────────────────────────────────────────
@@ -2546,6 +2569,51 @@ impl AccordContract {
                     },
                 );
             }
+            ProposalKind::ModifyRecurringPayment(params) => {
+                let mut schedule = read_recurring_payment(&env, params.schedule_id)?;
+                let status = derive_recurring_status(&env, &schedule);
+                if status == RecurringStatus::Cancelled || status == RecurringStatus::Completed {
+                    return Err(ContractError::ScheduleTerminal);
+                }
+
+                let previous_amount = schedule.amount;
+                let previous_interval = schedule.interval_secs;
+                let previous_end_time = schedule.end_time;
+
+                if let Some(amt) = params.new_amount {
+                    if amt < MIN_AMOUNT {
+                        return Err(ContractError::InvalidAmount);
+                    }
+                    schedule.amount = amt;
+                }
+                if let Some(inv) = params.new_interval_secs {
+                    if !(MIN_INTERVAL_SECS..=MAX_INTERVAL_SECS).contains(&inv) {
+                        return Err(ContractError::InvalidInterval);
+                    }
+                    schedule.interval_secs = inv;
+                }
+                if let Some(end_t) = params.new_end_time {
+                    if end_t <= schedule.start_time {
+                        return Err(ContractError::InvalidDeadline);
+                    }
+                    schedule.end_time = end_t;
+                }
+
+                write_recurring_payment(&env, &schedule);
+
+                env.events().publish(
+                    (symbol_short!("r_mod"),),
+                    RecurringPaymentModifiedEvent {
+                        schedule_id: params.schedule_id,
+                        previous_amount,
+                        new_amount: schedule.amount,
+                        previous_interval,
+                        new_interval: schedule.interval_secs,
+                        previous_end_time,
+                        new_end_time: schedule.end_time,
+                    },
+                );
+            }
         }
 
         proposal.status = ProposalStatus::Executed;
@@ -2844,6 +2912,91 @@ impl AccordContract {
         let id = read_next_id(&env);
 
         let p_kind = ProposalKind::ResumeRecurringPayment(schedule_id);
+
+        let proposal = Proposal {
+            id,
+            proposer: proposer.clone(),
+            description,
+            deadline,
+            approvals: 0,
+            approval_weight: 0,
+            status: ProposalStatus::Pending,
+            kind: p_kind,
+            ready_at: 0,
+            quorum_weight: threshold,
+            category: ProposalCategory::Ops,
+        };
+        write_proposal(&env, &proposal);
+        register_active_proposal(&env, id)?;
+
+        let next_id = id.checked_add(1).ok_or(ContractError::ArithmeticError)?;
+        write_next_id(&env, next_id);
+
+        let total_weight = read_total_weight(&env);
+        env.events().publish(
+            (symbol_short!("created"),),
+            ProposalCreatedEvent {
+                id,
+                proposer,
+                threshold,
+                category: ProposalCategory::Ops,
+                transfers: Vec::new(&env),
+                quorum_weight: threshold,
+                total_weight_at_creation: total_weight,
+            },
+        );
+
+        Ok(id)
+    }
+
+    pub fn create_modify_recurring_proposal(
+        env: Env,
+        proposer: Address,
+        schedule_id: u64,
+        new_amount: Option<i128>,
+        new_interval_secs: Option<u64>,
+        new_end_time: Option<u64>,
+        description: String,
+        deadline: u64,
+    ) -> Result<u64, ContractError> {
+        proposer.require_auth();
+        require_owner_and_weight(&env, &proposer)?;
+        require_not_frozen(&env)?;
+
+        let schedule = read_recurring_payment(&env, schedule_id)?;
+        let status = derive_recurring_status(&env, &schedule);
+        if status == RecurringStatus::Cancelled || status == RecurringStatus::Completed {
+            return Err(ContractError::ScheduleTerminal);
+        }
+
+        if let Some(amt) = new_amount {
+            if amt < MIN_AMOUNT {
+                return Err(ContractError::InvalidAmount);
+            }
+        }
+        if let Some(inv) = new_interval_secs {
+            if !(MIN_INTERVAL_SECS..=MAX_INTERVAL_SECS).contains(&inv) {
+                return Err(ContractError::InvalidInterval);
+            }
+        }
+        if let Some(end_t) = new_end_time {
+            if end_t <= schedule.start_time {
+                return Err(ContractError::InvalidDeadline);
+            }
+        }
+
+        validate_description(&description)?;
+        validate_deadline(&env, deadline)?;
+
+        let threshold = read_threshold(&env)?;
+        let id = read_next_id(&env);
+
+        let p_kind = ProposalKind::ModifyRecurringPayment(ModifyRecurringParams {
+            schedule_id,
+            new_amount,
+            new_interval_secs,
+            new_end_time,
+        });
 
         let proposal = Proposal {
             id,

--- a/contracts/accord/src/test.rs
+++ b/contracts/accord/src/test.rs
@@ -8600,6 +8600,66 @@ fn modify_recurring_payment_proposal_updates_schedule_parameters() {
     assert_eq!(updated_schedule.end_time, NOW + 172800);
 }
 
+// ── Issue #454: Execute-Time Re-Validation of Schedule Invariants ──
+
+#[test]
+fn execute_time_revalidation_rejects_invalid_state_transitions() {
+    let (env, client, owner_a, owner_b, owner_c, _, token_client) = setup(2);
+    let recipient = Address::generate(&env);
+    let amount = 1_000_000_i128;
+    let interval = 3600_u64;
+
+    let create_id = client.create_recurring_proposal(
+        &owner_a,
+        &recipient,
+        &token_client.address,
+        &amount,
+        &interval,
+        &NOW,
+        &(NOW + 86400),
+        &0_u64,
+        &10_000_000_i128,
+        &RecurringKind::FixedAmountPerPeriod,
+        &str(&env, "Schedule for invariant re-validation test"),
+        &DEADLINE,
+        &ProposalCategory::Ops,
+    );
+    client.approve(&owner_a, &create_id);
+    client.approve(&owner_b, &create_id);
+    client.execute(&owner_c, &create_id);
+
+    let schedule_id = 1_u64;
+
+    // Create Pause proposal and Cancel proposal concurrently when schedule is Active
+    let pause_prop_id = client.create_pause_recurring_proposal(
+        &owner_a,
+        &schedule_id,
+        &str(&env, "Pause schedule 1"),
+        &DEADLINE,
+    );
+    client.approve(&owner_a, &pause_prop_id);
+    client.approve(&owner_b, &pause_prop_id);
+
+    let cancel_prop_id = client.create_cancel_recurring_proposal(
+        &owner_a,
+        &schedule_id,
+        &str(&env, "Cancel schedule 1 concurrent"),
+        &DEADLINE,
+    );
+    client.approve(&owner_a, &cancel_prop_id);
+    client.approve(&owner_b, &cancel_prop_id);
+
+    // Execute Cancel proposal first so schedule becomes Cancelled
+    client.execute(&owner_c, &cancel_prop_id);
+    assert_eq!(client.get_recurring_payment(&schedule_id).status, RecurringStatus::Cancelled);
+
+    // Attempting to execute Pause proposal on now-Cancelled schedule fails at execute time with ScheduleTerminal
+    assert_eq!(
+        client.try_execute(&owner_c, &pause_prop_id),
+        Err(Ok(ContractError::ScheduleTerminal))
+    );
+}
+
 
 
 

--- a/contracts/accord/src/test.rs
+++ b/contracts/accord/src/test.rs
@@ -8488,6 +8488,61 @@ fn pause_and_resume_recurring_payment_proposals() {
     );
 }
 
+// ── Issue #452: Cancel Recurring Payment Proposal Kind ──
+
+#[test]
+fn cancel_recurring_payment_proposal_transitions_to_cancelled() {
+    let (env, client, owner_a, owner_b, owner_c, _, token_client) = setup(2);
+    let recipient = Address::generate(&env);
+    let amount = 1_000_000_i128;
+    let interval = 3600_u64;
+
+    let create_id = client.create_recurring_proposal(
+        &owner_a,
+        &recipient,
+        &token_client.address,
+        &amount,
+        &interval,
+        &NOW,
+        &(NOW + 86400),
+        &0_u64,
+        &10_000_000_i128,
+        &RecurringKind::FixedAmountPerPeriod,
+        &str(&env, "Schedule for cancel test"),
+        &DEADLINE,
+        &ProposalCategory::Ops,
+    );
+    client.approve(&owner_a, &create_id);
+    client.approve(&owner_b, &create_id);
+    client.execute(&owner_c, &create_id);
+
+    let schedule_id = 1_u64;
+    assert_eq!(client.get_recurring_payment(&schedule_id).status, RecurringStatus::Active);
+
+    // Create and execute Cancel proposal
+    let cancel_prop_id = client.create_cancel_recurring_proposal(
+        &owner_a,
+        &schedule_id,
+        &str(&env, "Cancel schedule 1"),
+        &DEADLINE,
+    );
+    client.approve(&owner_a, &cancel_prop_id);
+    client.approve(&owner_b, &cancel_prop_id);
+    client.execute(&owner_c, &cancel_prop_id);
+
+    assert_eq!(client.get_recurring_payment(&schedule_id).status, RecurringStatus::Cancelled);
+
+    assert_eq!(
+        client.try_create_cancel_recurring_proposal(
+            &owner_a,
+            &schedule_id,
+            &str(&env, "Cancel again"),
+            &DEADLINE,
+        ),
+        Err(Ok(ContractError::ScheduleAlreadyCancelled))
+    );
+}
+
 
 
 

--- a/contracts/accord/src/test.rs
+++ b/contracts/accord/src/test.rs
@@ -8408,6 +8408,86 @@ fn paused_schedule_cannot_disburse_and_resuming_is_non_retroactive() {
     );
 }
 
+// ── Issue #451: Pause and Resume Recurring Payment Proposal Kinds ──
+
+#[test]
+fn pause_and_resume_recurring_payment_proposals() {
+    let (env, client, owner_a, owner_b, owner_c, _, token_client) = setup(2);
+    let recipient = Address::generate(&env);
+    let amount = 1_000_000_i128;
+    let interval = 3600_u64;
+
+    let create_id = client.create_recurring_proposal(
+        &owner_a,
+        &recipient,
+        &token_client.address,
+        &amount,
+        &interval,
+        &NOW,
+        &(NOW + 86400),
+        &0_u64,
+        &10_000_000_i128,
+        &RecurringKind::FixedAmountPerPeriod,
+        &str(&env, "Schedule for pause/resume test"),
+        &DEADLINE,
+        &ProposalCategory::Ops,
+    );
+    client.approve(&owner_a, &create_id);
+    client.approve(&owner_b, &create_id);
+    client.execute(&owner_c, &create_id);
+
+    let schedule_id = 1_u64;
+    assert_eq!(client.get_recurring_payment(&schedule_id).status, RecurringStatus::Active);
+
+    // Create and execute Pause proposal
+    let pause_prop_id = client.create_pause_recurring_proposal(
+        &owner_a,
+        &schedule_id,
+        &str(&env, "Pause schedule 1"),
+        &DEADLINE,
+    );
+    client.approve(&owner_a, &pause_prop_id);
+    client.approve(&owner_b, &pause_prop_id);
+    client.execute(&owner_c, &pause_prop_id);
+
+    assert_eq!(client.get_recurring_payment(&schedule_id).status, RecurringStatus::Paused);
+
+    // Pausing an already paused schedule at creation is rejected
+    assert_eq!(
+        client.try_create_pause_recurring_proposal(
+            &owner_a,
+            &schedule_id,
+            &str(&env, "Pause again"),
+            &DEADLINE,
+        ),
+        Err(Ok(ContractError::ScheduleAlreadyPaused))
+    );
+
+    // Create and execute Resume proposal
+    let resume_prop_id = client.create_resume_recurring_proposal(
+        &owner_a,
+        &schedule_id,
+        &str(&env, "Resume schedule 1"),
+        &DEADLINE,
+    );
+    client.approve(&owner_a, &resume_prop_id);
+    client.approve(&owner_b, &resume_prop_id);
+    client.execute(&owner_c, &resume_prop_id);
+
+    assert_eq!(client.get_recurring_payment(&schedule_id).status, RecurringStatus::Active);
+
+    // Resuming an active schedule at creation is rejected
+    assert_eq!(
+        client.try_create_resume_recurring_proposal(
+            &owner_a,
+            &schedule_id,
+            &str(&env, "Resume active schedule"),
+            &DEADLINE,
+        ),
+        Err(Ok(ContractError::ScheduleNotPaused))
+    );
+}
+
 
 
 

--- a/contracts/accord/src/test.rs
+++ b/contracts/accord/src/test.rs
@@ -8543,6 +8543,63 @@ fn cancel_recurring_payment_proposal_transitions_to_cancelled() {
     );
 }
 
+// ── Issue #453: Modify Recurring Payment Proposal Kind ──
+
+#[test]
+fn modify_recurring_payment_proposal_updates_schedule_parameters() {
+    let (env, client, owner_a, owner_b, owner_c, _, token_client) = setup(2);
+    let recipient = Address::generate(&env);
+    let amount = 1_000_000_i128;
+    let interval = 3600_u64;
+
+    let create_id = client.create_recurring_proposal(
+        &owner_a,
+        &recipient,
+        &token_client.address,
+        &amount,
+        &interval,
+        &NOW,
+        &(NOW + 86400),
+        &0_u64,
+        &10_000_000_i128,
+        &RecurringKind::FixedAmountPerPeriod,
+        &str(&env, "Schedule for modify test"),
+        &DEADLINE,
+        &ProposalCategory::Ops,
+    );
+    client.approve(&owner_a, &create_id);
+    client.approve(&owner_b, &create_id);
+    client.execute(&owner_c, &create_id);
+
+    let schedule_id = 1_u64;
+    let initial_schedule = client.get_recurring_payment(&schedule_id);
+    assert_eq!(initial_schedule.amount, 1_000_000_i128);
+    assert_eq!(initial_schedule.interval_secs, 3600_u64);
+
+    let new_amount = Some(2_000_000_i128);
+    let new_interval = Some(7200_u64);
+    let new_end_time = Some(NOW + 172800);
+
+    // Create and execute Modify proposal
+    let modify_prop_id = client.create_modify_recurring_proposal(
+        &owner_a,
+        &schedule_id,
+        &new_amount,
+        &new_interval,
+        &new_end_time,
+        &str(&env, "Modify schedule 1"),
+        &DEADLINE,
+    );
+    client.approve(&owner_a, &modify_prop_id);
+    client.approve(&owner_b, &modify_prop_id);
+    client.execute(&owner_c, &modify_prop_id);
+
+    let updated_schedule = client.get_recurring_payment(&schedule_id);
+    assert_eq!(updated_schedule.amount, 2_000_000_i128);
+    assert_eq!(updated_schedule.interval_secs, 7200_u64);
+    assert_eq!(updated_schedule.end_time, NOW + 172800);
+}
+
 
 
 


### PR DESCRIPTION
This PR implements four lifecycle proposal features for recurring payments in AccordProtocol:
- Adds `PauseRecurringPayment` and `ResumeRecurringPayment` proposal kinds (#451)
- Adds `CancelRecurringPayment` proposal kind allowing terminal status transition (#452)
- Adds `ModifyRecurringPayment` proposal kind with before/after audit event emission (#453)
- Enforces execute-time re-validation of schedule invariants for all lifecycle proposals (#454)

Closes #454
Closes #452
Closes #453
Closes #451
