### PR TITLE
feat: weighted governance docs + CI weight invariant (#420–#427)

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -3,6 +3,7 @@ name: Smart Contract - Build & CI
 on:
   push:
     branches: [ main ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ main ]
 
@@ -135,7 +136,7 @@ jobs:
     name: Testnet Smoke Test
     runs-on: ubuntu-latest
     needs: ci
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - name: Check TESTNET_CONTRACT_ID is configured
@@ -166,3 +167,104 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         run: |
           echo "Deployed contract get_total_proposals returned: ${{ steps.invoke.outputs.result }}"
+
+  # Pre-mainnet deployment gate (issue #420).
+  # Runs on version tags (v*) that gate mainnet deployment. Queries the live
+  # testnet contract and fails if sum(owner weights) != get_total_weight.
+  # Skips cleanly when TESTNET_CONTRACT_ID is unset (same pattern as smoke test).
+  weight-invariant-gate:
+    name: Weight Invariant Gate
+    runs-on: ubuntu-latest
+    needs: ci
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Check TESTNET_CONTRACT_ID is configured
+        id: guard
+        run: |
+          if [ -z "${{ vars.TESTNET_CONTRACT_ID }}" ]; then
+            echo "TESTNET_CONTRACT_ID repository variable is not set — skipping weight invariant gate."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Stellar CLI
+        if: steps.guard.outputs.skip != 'true'
+        uses: stellar/stellar-cli@v25.0.0
+
+      - name: Verify total-weight invariant on testnet
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          CONTRACT_ID: ${{ vars.TESTNET_CONTRACT_ID }}
+        run: |
+          set -euo pipefail
+          weights_raw=$(stellar contract invoke \
+            --network testnet \
+            --id "$CONTRACT_ID" \
+            -- get_owner_weights)
+          total_raw=$(stellar contract invoke \
+            --network testnet \
+            --id "$CONTRACT_ID" \
+            -- get_total_weight)
+
+          export WEIGHTS_RAW="$weights_raw"
+          export TOTAL_RAW="$total_raw"
+
+          python3 <<'PY'
+          import json, os, re, sys
+
+          def parse_u32(value):
+              if isinstance(value, bool):
+                  raise TypeError(value)
+              if isinstance(value, int):
+                  return value
+              if isinstance(value, str):
+                  return int(value, 10)
+              raise TypeError(type(value))
+
+          def extract_weight(entry):
+              if isinstance(entry, dict):
+                  for key, val in entry.items():
+                      if str(key).lower() == "weight":
+                          return parse_u32(val)
+              raise ValueError(f"Cannot read weight from entry: {entry!r}")
+
+          weights_raw = os.environ["WEIGHTS_RAW"].strip()
+          total_raw = os.environ["TOTAL_RAW"].strip()
+
+          try:
+              weights = json.loads(weights_raw)
+          except json.JSONDecodeError:
+              found = re.findall(r'"?weight"?\s*[:=]\s*"?(\d+)"?', weights_raw, flags=re.I)
+              if not found:
+                  print("Failed to parse get_owner_weights output:", weights_raw, file=sys.stderr)
+                  sys.exit(1)
+              summed = sum(int(w) for w in found)
+          else:
+              if not isinstance(weights, list):
+                  print("Expected a list from get_owner_weights, got:", type(weights), file=sys.stderr)
+                  sys.exit(1)
+              summed = sum(extract_weight(entry) for entry in weights)
+
+          try:
+              reported = parse_u32(json.loads(total_raw))
+          except Exception:
+              m = re.search(r"\d+", total_raw)
+              if not m:
+                  print("Failed to parse get_total_weight output:", total_raw, file=sys.stderr)
+                  sys.exit(1)
+              reported = int(m.group(0))
+
+          print(f"sum(owner weights) = {summed}")
+          print(f"get_total_weight   = {reported}")
+
+          if summed != reported:
+              print(
+                  "Weight invariant failed: sum of owner weights does not equal reported total weight.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          print("Weight invariant OK.")
+          PY

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,15 +79,18 @@ Each key is a separate `LedgerEntry` with its own independently tracked TTL.
 ### Proposal Struct Fields
 
 ```
-id            u64
-proposer      Address
-to            Address
-amount        i128          (token's native unit — stroop for XLM-derived tokens)
-token         Address       (Soroban token contract)
-description   String        (max 300 chars)
-deadline      u64           (Unix timestamp)
-approvals     u32
-status        ProposalStatus
+id               u64
+proposer         Address
+description      String        (max 300 chars)
+deadline         u64           (Unix timestamp)
+approvals        u32           (cumulative approval weight; kept in sync with approval_weight)
+approval_weight  u32           (cumulative approval weight credited from approvers)
+status           ProposalStatus
+kind             ProposalKind  (Transfer | AddOwner | RemoveOwner | ChangeThreshold |
+                                SetSpendingLimit | ChangeOwnerWeight | recurring variants)
+ready_at         u64           (ledger time when quorum was first reached; 0 if not yet)
+quorum_weight    u32           (threshold snapshotted at proposal creation)
+category         ProposalCategory
 ```
 
 ### Key Naming Conventions
@@ -238,6 +241,54 @@ When an entry's TTL reaches zero the Stellar network **permanently deletes** it 
 - Deletion of the contract instance entry (`INIT`, `THRESH`, `NEXT`, `ACTCNT`, `TLOCK`) bricks the entire contract; a fresh deployment and re-initialisation is the only recovery.
 
 For long-lived multisigs, ensure at least one on-chain call touches the contract within every 30-day window (for example, a periodic `get_threshold` call) to keep the instance alive.
+
+## Weighted Governance Model
+
+Accord Protocol evolved from a flat M-of-N approval count into **weighted governance**: each owner carries an individual voting weight, proposals become `Ready` when accumulated approval weight meets a snapshotted quorum, and the contract maintains a total-weight counter that must always equal the sum of current owner weights.
+
+### Weighted data model
+
+| Concept | Where it lives | Meaning |
+|---------|----------------|---------|
+| Per-owner weight | Persistent `OWNERS` map (`Address → u32`) | Each registered owner's raw voting weight (`MIN_OWNER_WEIGHT`..=`MAX_OWNER_WEIGHT`) |
+| Total weight | Instance key `TWGT` (`u32`) | Running sum of all owner weights; updated on initialize, add/remove owner, and `ChangeOwnerWeight` |
+| Threshold / required quorum | Instance key `THRESH` (`u32`) | Absolute weight a **new** proposal must reach; also returned by `get_required_quorum_weight` |
+| Proposal quorum | `Proposal.quorum_weight` | Copy of the threshold at **proposal creation** — frozen for that proposal's lifetime |
+| Proposal approval progress | `Proposal.approvals` / `Proposal.approval_weight` | Cumulative effective weight from owners who have approved (delegation-aware at approve time) |
+| Per-approver contribution | Persistent `("APPR", id, owner)` weight | Weight credited when that owner approved, so `revoke` can subtract the same amount |
+
+Bounds enforced by the contract:
+
+- Per-owner weight: `1` … `100_000`
+- Max owners: `20` → theoretical max total weight `2_000_000`
+- Default single-owner cap for `ChangeOwnerWeight`: **50%** of resulting total weight (`MAX_SINGLE_OWNER_WEIGHT_PCT`)
+
+Read paths for operators and frontends: `get_owner_weight`, `get_owner_weights`, `get_total_weight`, `get_required_quorum_weight`, `get_proposal_approval_progress`.
+
+### Quorum computation and approval accumulation
+
+1. **At creation** — Every proposal-creation entrypoint reads the current threshold and stores it as `quorum_weight` on the new `Proposal`. It also emits `total_weight_at_creation` on the `created` event so auditors can reconstruct context even after later ownership changes. Changing `THRESH` afterward does **not** rewrite existing proposals' `quorum_weight`.
+
+2. **On approve** — The contract loads the approver's raw weight from `OWNERS`, computes **effective weight** (raw ± active delegations), records that value under `("APPR", id, owner)`, and adds it to both `approvals` and `approval_weight`.
+
+3. **Ready transition** — `derive_status` marks a proposal `Ready` when `approvals >= quorum_weight` (and the deadline has not passed). The same comparison gates `execute`.
+
+4. **On revoke** — The stored per-approver weight is subtracted from the cumulative totals so a weight change after approve cannot leave inconsistent counters.
+
+Invariant operators must preserve: **sum(`get_owner_weights`) == `get_total_weight`**. Governance executions that would leave any active proposal's `quorum_weight` unreachable (`WouldBreakQuorum`) are rejected.
+
+### How this differs from flat M-of-N
+
+| | Flat M-of-N (original) | Weighted governance (current) |
+|--|------------------------|-------------------------------|
+| Owner vote | Every approval counts as `1` | Each approval contributes that owner's weight |
+| Threshold meaning | “M distinct owners must approve” | “At least `threshold` weight must approve” |
+| Owner storage | List of addresses | Map of address → weight |
+| Ready condition | `approval_count >= M` | `approval_weight >= quorum_weight` |
+| Changing power | Add/remove owners only | Also `ChangeOwnerWeight(target, new_weight)` |
+| Equal weights | Native model | Still supported: set every weight to `1` and `threshold = M` — behaviour matches classical M-of-N |
+
+**Equal weights reduce to the old model.** A 2-of-3 multisig with weights `[1, 1, 1]` and threshold `2` still needs any two owners. Skewed weights (for example `[5, 3, 2]` with threshold `6`) let larger stakeholders carry more influence while still requiring coalition approvals when no single owner meets quorum alone. Legacy deployments that predate weights can call `migrate_to_weighted_governance` once (after upgrading WASM) to assign weight `1` to every existing owner.
 
 ## 4. Proposal Lifecycle
 

--- a/docs/CONTRACT_API.md
+++ b/docs/CONTRACT_API.md
@@ -953,8 +953,69 @@ When calling contract functions from JavaScript, each parameter must be converte
 | `i128` | `ScVal::I128` | `nativeToScVal(BigInt(n), { type: 'i128' })` | `scValToNative(scval)` → JavaScript `BigInt` |
 | `String` | `ScVal::String` | `nativeToScVal(s, { type: 'string' })` | `scValToNative(scval)` → JavaScript `String` |
 | `bool` | `ScVal::Bool` | `nativeToScVal(b, { type: 'bool' })` | `scValToNative(scval)` → JavaScript `Boolean` |
-| `Proposal` | `ScVal::Map` | N/A (output only) | `scValToNative(scval)` → plain JavaScript object whose field names match the `Proposal` struct in [ARCHITECTURE.md §3](../ARCHITECTURE.md#3-storage-layout-soroban) |
+| `Proposal` | `ScVal::Map` | N/A (output only) | `scValToNative(scval)` → object with the fields below (see also [ARCHITECTURE.md §3](./ARCHITECTURE.md#3-storage-layout-soroban)) |
+| `OwnerWeight` | `ScVal::Map` | N/A (output only) | `{ owner: "G…", weight: number }` |
+| `ProposalKind` | `ScVal::Vec` / enum | Built by the SDK when forming governance calls | Discriminated union — variants listed below |
 | `()` (unit) | `ScVal::Void` | N/A (no input) | `scValToNative(scval)` → `undefined` |
+
+### `Proposal` fields (weighted governance)
+
+Decoded `Proposal` maps include these weight-related fields alongside the rest of the proposal state:
+
+| Field | Rust Type | XDR SCVal Type | Description |
+|-------|-----------|----------------|-------------|
+| `quorum_weight` | `u32` | `ScVal::U32` | Absolute weight this proposal must accumulate to become `Ready`. Snapshotted from `THRESH` / `get_required_quorum_weight()` at creation. |
+| `approval_weight` | `u32` | `ScVal::U32` | Cumulative effective weight from owners who have approved so far. |
+| `approvals` | `u32` | `ScVal::U32` | Same running total as `approval_weight` (legacy field name retained for compatibility; both are updated together in `approve` / `revoke`). |
+| `kind` | `ProposalKind` | enum / nested vals | Action this proposal will perform when executed (see variants below). |
+
+```rust
+struct Proposal {
+    id: u64,
+    proposer: Address,
+    description: String,
+    deadline: u64,
+    approvals: u32,
+    approval_weight: u32,
+    status: ProposalStatus,
+    kind: ProposalKind,
+    ready_at: u64,
+    quorum_weight: u32,
+    category: ProposalCategory,
+}
+```
+
+### `ProposalKind` variants
+
+| Variant | Payload | Purpose |
+|---------|---------|---------|
+| `Transfer` | `Vec<Transfer>` | Multi-asset treasury transfer |
+| `AddOwner` | `(Address, u32)` | Add owner with initial weight |
+| `RemoveOwner` | `Address` | Remove an owner |
+| `ChangeThreshold` | `u32` | Change the quorum threshold (absolute weight) |
+| `SetSpendingLimit` | `(Address, Address, i128)` | Per-owner per-token spending limit |
+| `ChangeOwnerWeight` | `(Address /* target_owner */, u32 /* new_weight */)` | Update an existing owner's voting weight (must be ≥ 1; use `RemoveOwner` instead of zeroing) |
+| `CreateRecurringPayment` | `CreateRecurringParams` | Create a recurring payment schedule |
+| `CancelRecurringPayment` | `u64` | Cancel schedule by id |
+| `PauseRecurringPayment` | `u64` | Pause schedule by id |
+| `ResumeRecurringPayment` | `u64` | Resume a paused schedule |
+| `ModifyRecurringPayment` | `ModifyRecurringParams` | Adjust schedule parameters |
+
+```rust
+enum ProposalKind {
+    Transfer(Vec<Transfer>),
+    AddOwner(Address, u32),
+    RemoveOwner(Address),
+    ChangeThreshold(u32),
+    SetSpendingLimit(Address, Address, i128),
+    ChangeOwnerWeight(Address, u32),
+    CreateRecurringPayment(CreateRecurringParams),
+    CancelRecurringPayment(u64),
+    PauseRecurringPayment(u64),
+    ResumeRecurringPayment(u64),
+    ModifyRecurringPayment(ModifyRecurringParams),
+}
+```
 
 ---
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -10,5 +10,6 @@ Beginner-friendly guides for using Accord Protocol.
 | [Payroll Multisig](payroll-multisig.md) | Pay contributors monthly in USDC through a 2-of-3 multisig |
 | [Payroll with Recurring Payments](payroll-recurring.md) | Set up automated monthly payroll schedules or linear token vesting with cliffs |
 | [Grant Management](grant-management.md) | Disburse USDC grants through a multisig with a grants committee |
+| [Choosing Voting Weights](weighted-governance.md) | Decide when equal vs skewed owner weights make sense, with examples and centralization risks |
 | [Monitoring Your Multisig](monitoring-your-multisig.md) | Query Horizon events, spot missed executions, and verify state after an upgrade |
 | [Troubleshooting](troubleshooting.md) | Diagnose wallet, transaction, and network errors |

--- a/docs/guides/weighted-governance.md
+++ b/docs/guides/weighted-governance.md
@@ -1,0 +1,116 @@
+# Choosing Voting Weights
+
+Weighted governance lets each Accord owner carry a different voting weight. Quorum is an absolute weight target (`threshold` / `quorum_weight`), not “M distinct people,” so how you assign weights decides who can move funds alone, who must form coalitions, and how resilient the multisig stays if one key is lost or compromised.
+
+This guide helps teams choose **equal** versus **skewed** weights. For the on-chain data model and quorum math, see [Weighted Governance Model](../ARCHITECTURE.md#weighted-governance-model) in `ARCHITECTURE.md`.
+
+---
+
+## Equal weights
+
+Give every owner the same weight (usually `1`) and set `threshold` to the classic M in M-of-N.
+
+**Example — classical 2-of-3**
+
+| Owner | Weight |
+|-------|--------|
+| Alice | 1 |
+| Bob | 1 |
+| Carol | 1 |
+
+- Total weight = `3`
+- Threshold = `2`
+- Any two owners can approve; no single owner can act alone
+
+**When equal weights make sense**
+
+- Founders or partners who share custody as peers
+- Committees where each seat should count the same
+- Teams migrating from flat M-of-N (`migrate_to_weighted_governance` assigns weight `1` to everyone)
+- You want the simplest mental model and the least centralization risk
+
+**Trade-off:** You cannot express “ops lead has more say than a backup signer” without changing the owner set or using skewed weights.
+
+---
+
+## Skewed weights
+
+Assign larger weights to owners who should carry more influence, and set `threshold` to the coalition size you want (in weight units).
+
+**Example — lead + two backups (still needs a partner)**
+
+| Owner | Weight | Share of total |
+|-------|--------|----------------|
+| Lead | 5 | ~50% |
+| Backup A | 3 | ~30% |
+| Backup B | 2 | ~20% |
+
+- Total weight = `10`
+- Threshold = `6` → Lead + either backup works; Lead alone (`5`) cannot; both backups (`5`) cannot
+
+**Example — five-seat board with chair slightly heavier**
+
+| Owner | Weight |
+|-------|--------|
+| Chair | 3 |
+| Member A–D | 2 each |
+
+- Total weight = `11`
+- Threshold = `7` → needs broad agreement; chair alone is far from quorum
+
+**When skewed weights make sense**
+
+- One operator runs day-to-day proposals but must not unlock the treasury alone
+- Investors or grant committees with unequal economic stake
+- A backup / emergency signer should help reach quorum without matching the primary’s power
+
+**Hard rule from the contract:** `ChangeOwnerWeight` cannot push any one owner above the configured single-owner cap (default **50%** of resulting total weight). Prefer designs where **no** owner’s weight alone meets `threshold`.
+
+---
+
+## Centralization risks
+
+Concentrated weight looks like a multisig in the UI but behaves like a hot wallet on-chain:
+
+| Risk | What goes wrong |
+|------|-----------------|
+| Single owner ≥ threshold | That owner can approve and execute alone — one compromised key drains the treasury |
+| Near-cap whale + small allies | A small colluding set reaches quorum while others are decorative |
+| Gradual weight raises | A sequence of individually-valid `ChangeOwnerWeight` proposals can still concentrate power in a coalition |
+| Unbalanced `initialize` | The single-owner cap applies to later weight changes; **initial** weights are the deployer’s responsibility — review them as carefully as threshold |
+
+**Mitigations operators should apply**
+
+1. Keep every owner’s share **below** threshold (and ideally well under the 50% cap).
+2. Review `get_owner_weights` and `get_total_weight` after every governance execution.
+3. Treat weight-change proposals like key rotations: announce off-chain, rebuild consensus, then approve.
+4. Prefer equal weights unless you have a clear reason to skew.
+
+---
+
+## Quick chooser
+
+| Situation | Suggested starting point |
+|-----------|--------------------------|
+| Peer founders / equal partners | Equal weights, classic M-of-N threshold |
+| One operator + backups | Skewed, threshold above the operator’s weight |
+| Large committee, equal seats | Equal weights, higher M |
+| Need “veto-ish” large holder without sole control | Skewed but holder weight below threshold; threshold requires at least one other owner |
+
+After you pick numbers, confirm with:
+
+```bash
+stellar contract invoke --network testnet --id CONTRACT_ID -- get_owner_weights
+stellar contract invoke --network testnet --id CONTRACT_ID -- get_total_weight
+stellar contract invoke --network testnet --id CONTRACT_ID -- get_required_quorum_weight
+```
+
+The sum of owner weights must equal `get_total_weight`. If you are preparing a mainnet tag, CI also checks that invariant against the configured testnet deployment.
+
+---
+
+## Related docs
+
+- [Weighted Governance Model](../ARCHITECTURE.md#weighted-governance-model)
+- [Team Multisig](team-multisig.md)
+- [Deployment — migrate to weighted governance](../DEPLOYMENT.md)


### PR DESCRIPTION
## Summary

Implements the four assigned weighted-governance issues:

#420
#421
#426
#427

- **#420** — Pre-deployment CI gate on `v*` tags verifying `sum(get_owner_weights) == get_total_weight` against live testnet; skips cleanly when `TESTNET_CONTRACT_ID` is unset
- **#421** — “Weighted Governance Model” deep-dive in `docs/ARCHITECTURE.md` (data model, quorum/approval accumulation, contrast with flat M-of-N)
- **#426** — XDR type reference updates for `quorum_weight` / `approval_weight` and `ChangeOwnerWeight` (plus full `ProposalKind` listing) in `docs/CONTRACT_API.md`
- **#427** — New `docs/guides/weighted-governance.md` on equal vs skewed weights, examples, and centralization risks; indexed in `docs/guides/README.md`

Closes #420
Closes #421
Closes #426
Closes #427

## Test plan

- [ ] Confirm branch is based on latest `main` with no merge conflicts
- [ ] Skim Architecture “Weighted Governance Model” for accuracy vs `contracts/accord/src/lib.rs`
- [ ] Confirm XDR section lists `quorum_weight`, `approval_weight`, and `ChangeOwnerWeight`
- [ ] Open the new weights guide from `docs/guides/README.md`
- [ ] Confirm `.github/workflows/contract.yml` is valid YAML and the Weight Invariant Gate job is tag-only (`v*`)