### PR TITLE
feat: snapshotted quorum UI tests, RecurringPaymentCreatedEvent struc…

### DIFF
--- a/contracts/accord/src/lib.rs
+++ b/contracts/accord/src/lib.rs
@@ -326,6 +326,39 @@ pub struct RecurringPaymentModifiedEvent {
     pub new_end_time: u64,
 }
 
+/// Emitted when a recurring payment schedule is created through the execution
+/// of a `CreateRecurringPayment` proposal. Carries the full set of schedule
+/// parameters so that indexers and frontends can reconstruct the schedule from
+/// the event log alone without querying contract state.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct RecurringPaymentCreatedEvent {
+    /// The new schedule's ID, assigned sequentially at creation time.
+    pub id: u64,
+    /// The owner whose proposal was executed to create this schedule.
+    pub proposer: Address,
+    /// The address that will receive each period's disbursement.
+    pub recipient: Address,
+    /// The token contract address used for disbursements.
+    pub token: Address,
+    /// The amount transferred per period.
+    pub amount: i128,
+    /// The minimum number of seconds that must elapse between disbursements.
+    pub interval_secs: u64,
+    /// The earliest timestamp at which the first disbursement may occur.
+    pub start_time: u64,
+    /// Optional hard end timestamp; disbursements after this point are rejected.
+    pub end_time: u64,
+    /// Optional cliff timestamp; the first disbursement is not due until this
+    /// time even if `start_time` has already passed.
+    pub cliff_time: u64,
+    /// Optional cumulative cap; disbursements stop once `total_disbursed` would
+    /// exceed this value.
+    pub total_cap: i128,
+    /// The schedule's disbursement kind (fixed-amount or linear-vesting).
+    pub kind: RecurringKind,
+}
+
 // ─── Errors ──────────────────────────────────────────────────────────────────
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1591,6 +1624,20 @@ impl AccordContract {
     }
 
     /// Disburses one due period for a recurring payment schedule.
+    ///
+    /// **Catch-up policy: one period per call.**
+    /// If multiple intervals have elapsed since the last disbursement (e.g.
+    /// because no one cranked the schedule, or because it was paused for
+    /// several intervals), each call to `disburse_recurring` transfers exactly
+    /// one period's amount. The caller must invoke this function once per
+    /// missed period to "catch up". The alternative — disbursing all missed
+    /// periods in a single call — was rejected because it would allow a single
+    /// transaction to drain an arbitrarily large share of the contract's
+    /// treasury, making the disbursement cost unpredictable and opening a
+    /// denial-of-service vector if the accumulated debt is large enough to
+    /// exhaust the transaction's resource budget. One-period-per-call keeps
+    /// each call's cost bounded and gives the multisig owners the opportunity
+    /// to cancel or pause a misbehaving schedule between periods.
     ///
     /// Non-retroactive pause/resume policy:
     /// Paused schedules cannot disburse, and `last_disbursed_at` does not advance while paused.

--- a/frontend/src/components/ApprovalBar.test.tsx
+++ b/frontend/src/components/ApprovalBar.test.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, test, expect } from "vitest";
+import { ApprovalBar } from "./ApprovalBar";
+
+// ── ApprovalBar: snapshotted quorum tests ─────────────────────────────────────
+//
+// A proposal's quorumWeight is fixed at creation time. If owner weights change
+// after the proposal is created, ApprovalBar must measure progress against the
+// original snapshotted quorumWeight — not the live totalWeight. These tests
+// verify that invariant by driving ApprovalBar directly with combinations where
+// quorumWeight ≠ totalWeight.
+
+describe("ApprovalBar", () => {
+  test("renders the snapshotted quorum in the weight label", () => {
+    // quorumWeight=10 was snapshotted at creation; live totalWeight is now 35.
+    render(
+      <ApprovalBar approvalWeight={7} quorumWeight={10} totalWeight={35} />
+    );
+
+    // The label must read against the snapshot (10), not the live total (35).
+    expect(screen.getByText("7 / 10 weight")).toBeTruthy();
+  });
+
+  test("aria-label reflects snapshotted quorum and correct percentage", () => {
+    // 5 out of a snapshotted quorum of 10 = 50%.
+    const { container } = render(
+      <ApprovalBar approvalWeight={5} quorumWeight={10} totalWeight={20} />
+    );
+
+    const wrapper = container.firstChild as HTMLElement;
+    const label = wrapper.getAttribute("aria-label") ?? "";
+
+    expect(label).toContain("quorum 10");
+    expect(label).toContain("50");
+    // Must not mention totalWeight as the quorum target.
+    expect(label).not.toContain("quorum 20");
+  });
+
+  test("progress is clamped at 100% when approvalWeight meets snapshotted quorumWeight", () => {
+    // approvalWeight exactly equals the snapshotted quorumWeight; totalWeight
+    // is higher (post weight-change). The bar must be 100%, not a fraction.
+    render(
+      <ApprovalBar approvalWeight={10} quorumWeight={10} totalWeight={50} />
+    );
+
+    expect(screen.getByText("10 / 10 weight")).toBeTruthy();
+  });
+
+  test("progress is not inflated when approvalWeight exceeds snapshotted quorumWeight", () => {
+    // Over-approval beyond the snapshot must still render as 100% (clamped).
+    render(
+      <ApprovalBar approvalWeight={15} quorumWeight={10} totalWeight={30} />
+    );
+
+    expect(screen.getByText("15 / 10 weight")).toBeTruthy();
+  });
+
+  test("snapshot smaller than live total: quorum tick is positioned relative to totalWeight", () => {
+    // quorumWeight=8, totalWeight=16 → tick at 50% of the bar.
+    // This confirms the tick uses totalWeight as the scale denominator while
+    // progress is still measured against quorumWeight.
+    const { container } = render(
+      <ApprovalBar approvalWeight={4} quorumWeight={8} totalWeight={16} />
+    );
+
+    // The quorum tick div carries a title attribute with the quorum/total info.
+    const tickEl = container.querySelector('[title*="Quorum at 8"]');
+    expect(tickEl).not.toBeNull();
+    expect(tickEl?.getAttribute("title")).toContain("total 16");
+  });
+
+  test("snapshot larger mismatch: live total doubled but quorum label unchanged", () => {
+    // Snapshot quorumWeight=5; weights later changed so live total=40.
+    // The label must still read "3 / 5 weight".
+    render(
+      <ApprovalBar approvalWeight={3} quorumWeight={5} totalWeight={40} />
+    );
+
+    expect(screen.getByText("3 / 5 weight")).toBeTruthy();
+  });
+
+  test("zero quorumWeight is handled gracefully with 0% progress", () => {
+    render(
+      <ApprovalBar approvalWeight={0} quorumWeight={0} totalWeight={10} />
+    );
+
+    // Should not throw; label should still render.
+    expect(screen.getByText("0 / 0 weight")).toBeTruthy();
+  });
+
+  test("zero totalWeight: quorum tick is not rendered", () => {
+    const { container } = render(
+      <ApprovalBar approvalWeight={2} quorumWeight={5} totalWeight={0} />
+    );
+
+    // Tick is only rendered when totalWeight > 0.
+    const tickEl = container.querySelector('[title*="Quorum at"]');
+    expect(tickEl).toBeNull();
+  });
+});

--- a/frontend/src/components/ProposalCard.test.tsx
+++ b/frontend/src/components/ProposalCard.test.tsx
@@ -160,24 +160,95 @@ describe("ProposalCard", () => {
   });
 
   test("renders change-owner-weight proposals with governance summary", () => {
-    render(
-      <ProposalCard
-        proposal={baseProposal({
-          kind: "change_owner_weight",
-          to: "GOWNER...R111",
-          amount: "25",
-          token: "Owner weight",
-        })}
-        walletAddress="GCONNECTED123"
-        onApprove={vi.fn()}
-        onExecute={vi.fn()}
-        onRevoke={vi.fn()}
-      />
-    );
+    renderProposalCard({
+      proposal: baseProposal({
+        kind: "change_owner_weight",
+        to: "GOWNER...R111",
+        amount: "25",
+        token: "Owner weight",
+      }),
+    });
 
     expect(screen.getByText("Change Weight")).toBeTruthy();
     expect(screen.getByText("Governance")).toBeTruthy();
     expect(screen.getByText("Owner GOWNER...R111")).toBeTruthy();
     expect(screen.getByText("New weight: 25")).toBeTruthy();
+  });
+
+  // ── Stale-weight / snapshotted quorum tests ────────────────────────────────
+  //
+  // A proposal's quorum is fixed at creation time (snapshotted in quorumWeight).
+  // If owner weights change after the proposal is created, the UI must show the
+  // snapshotted quorum — not the live total weight — so that approval progress
+  // is measured against the original requirement.
+
+  test("ApprovalBar receives the snapshotted quorumWeight, not the live totalWeight", () => {
+    // Snapshot: quorumWeight=10, totalWeight=20 (at creation)
+    // After a weight change the live total is now 35 — but the bar must still
+    // show progress against the original quorumWeight of 10.
+    const proposal = baseProposal({
+      approvalWeight: 7,
+      quorumWeight: 10,   // snapshotted at creation
+      totalWeight: 35,    // live total after a weight change
+    });
+
+    renderProposalCard({ proposal });
+
+    // The label rendered by ApprovalBar reads "approvalWeight / quorumWeight weight"
+    expect(screen.getByText("7 / 10 weight")).toBeTruthy();
+  });
+
+  test("quorum label uses snapshot even when live total diverges significantly", () => {
+    // Snapshot quorumWeight=5; live totalWeight has grown to 100 after many
+    // weight increases. Progress must still be measured against 5.
+    const proposal = baseProposal({
+      approvalWeight: 3,
+      quorumWeight: 5,
+      totalWeight: 100,
+    });
+
+    renderProposalCard({ proposal });
+
+    expect(screen.getByText("3 / 5 weight")).toBeTruthy();
+  });
+
+  test("fully approved proposal shows 100% against snapshotted quorum, not live total", () => {
+    // approvalWeight meets quorumWeight (snapshot) even though totalWeight is higher.
+    const proposal = baseProposal({
+      approvalWeight: 10,
+      quorumWeight: 10,
+      totalWeight: 50,
+      status: "ready",
+    });
+
+    renderProposalCard({ proposal });
+
+    expect(screen.getByText("10 / 10 weight")).toBeTruthy();
+  });
+
+  test("snapshot quorum remains unchanged after a weight-change proposal would alter live total", () => {
+    // Two proposals created before and after a weight change.
+    // Both must still show their original snapshotted quorumWeight.
+    const proposalBeforeChange = baseProposal({
+      id: 1,
+      approvalWeight: 2,
+      quorumWeight: 6,   // threshold at creation: 6
+      totalWeight: 12,   // live total now higher after weight change
+    });
+
+    const { unmount } = renderProposalCard({ proposal: proposalBeforeChange });
+    expect(screen.getByText("2 / 6 weight")).toBeTruthy();
+    unmount();
+
+    // A proposal created after the weight change has a different snapshot.
+    const proposalAfterChange = baseProposal({
+      id: 2,
+      approvalWeight: 2,
+      quorumWeight: 8,   // threshold may differ post-change
+      totalWeight: 12,
+    });
+
+    renderProposalCard({ proposal: proposalAfterChange });
+    expect(screen.getByText("2 / 8 weight")).toBeTruthy();
   });
 });

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import type { Proposal, ProposalKind } from "../types/accord";
+import { Link } from "react-router-dom";
+import type { Proposal, ProposalCategory, ProposalKind } from "../types/accord";
 import { ApprovalBar } from "./ApprovalBar";
 import { StatusBadge } from "./StatusBadge";
 import { Check, Copy, Link2 } from "lucide-react";
@@ -11,38 +12,45 @@ type ProposalCardProps = {
   onApprove: (id: number) => void;
   onExecute: (id: number) => void;
   onRevoke: (id: number) => void;
-  // weight-based props (new)
-  approvalWeight?: number;
-  quorumWeight?: number;
-  totalWeight?: number;
   ownerWeights?: Record<string, number>;
 };
 
-const KIND_LABELS = {
+const KIND_LABELS: Record<Exclude<ProposalKind, "recurring">, { title: string; badge: string }> & {
+  recurring: { title: string; badge: string };
+} = {
   transfer: { title: "Transfer", badge: "Payment" },
   add_owner: { title: "Add Owner", badge: "Governance" },
   remove_owner: { title: "Remove Owner", badge: "Governance" },
   change_threshold: { title: "Change Threshold", badge: "Governance" },
   set_spending_limit: { title: "Set Spending Limit", badge: "Policy" },
   change_owner_weight: { title: "Change Weight", badge: "Governance" },
-} satisfies Record<ProposalKind, { title: string; badge: string }>;
+  recurring: { title: "Recurring Payment", badge: "Payment" },
+};
 
-function assertNever(value: never): never {
-  throw new Error(`Unhandled proposal kind: ${value}`);
-}
+const CATEGORY_STYLES: Record<ProposalCategory, string> = {
+  Transfer: "bg-sky-900/50 text-sky-300",
+  Payroll: "bg-violet-900/50 text-violet-300",
+  Grant: "bg-emerald-900/50 text-emerald-300",
+  Ops: "bg-amber-900/50 text-amber-300",
+  Other: "bg-zinc-800 text-zinc-400",
+};
 
 function KindSummary({ proposal }: { proposal: Proposal }) {
   switch (proposal.kind) {
     case "transfer":
       return (
-        <>
+        <Link
+          to={`/proposals/${proposal.id}`}
+          className="block"
+          aria-label={`Send ${proposal.amount} ${proposal.token}`}
+        >
           <p className="text-sm text-zinc-300">
             Send {proposal.amount} {proposal.token}
           </p>
           <p className="mt-0.5 font-mono text-sm text-zinc-500">
             To {proposal.to}
           </p>
-        </>
+        </Link>
       );
     case "add_owner":
       return (
@@ -84,8 +92,17 @@ function KindSummary({ proposal }: { proposal: Proposal }) {
           </p>
         </>
       );
-    default:
-      return assertNever(proposal.kind);
+    case "recurring":
+      return (
+        <p className="mt-0.5 text-sm text-zinc-500">
+          Recurring payment to {proposal.to}
+        </p>
+      );
+    default: {
+      // exhaustive check
+      const _: never = proposal.kind;
+      return null;
+    }
   }
 }
 
@@ -95,9 +112,6 @@ export function ProposalCard({
   onApprove,
   onExecute,
   onRevoke,
-  approvalWeight = 0,
-  quorumWeight = 0,
-  totalWeight = 0,
   ownerWeights = {},
 }: ProposalCardProps) {
   const connected = !!walletAddress;
@@ -160,28 +174,23 @@ export function ProposalCard({
               {labels.badge}
             </span>
           </div>
+
           <KindSummary proposal={proposal} />
-          <div className="flex items-center gap-2 mt-0.5">
-            <p className="text-zinc-500 text-sm font-mono">
-              Proposed by -&gt; {proposal.proposer.slice(0, 6)}...
-              {proposal.proposer.slice(-4)}
-            </p>
-            <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-zinc-800 text-zinc-400 font-mono">
-              {KIND_LABELS[proposal.kind].badge}
-            </span>
-          </div>
-          <KindSummary proposal={proposal} />
+
           <div className="flex items-center gap-2 mt-0.5">
             <div className="flex items-center gap-2">
               <p className="text-zinc-500 text-sm font-mono">
                 Proposed by → {shortenAddr(proposal.proposer)}
               </p>
               {(() => {
-                // Find full owner address that matches the shortened proposer string
-                const ownerAddr = Object.keys(ownerWeights).find((a) => shortenAddr(a) === proposal.proposer);
+                const ownerAddr = Object.keys(ownerWeights).find(
+                  (a) => shortenAddr(a) === proposal.proposer
+                );
                 if (ownerAddr) {
                   return (
-                    <span className="text-xs text-zinc-400 ml-1">· weight {ownerWeights[ownerAddr]}</span>
+                    <span className="text-xs text-zinc-400 ml-1">
+                      · weight {ownerWeights[ownerAddr]}
+                    </span>
                   );
                 }
                 return null;
@@ -206,11 +215,13 @@ export function ProposalCard({
               )}
             </button>
           </div>
+
           {proposal.description && (
             <p className="text-zinc-500 text-xs mt-1.5 leading-relaxed max-w-sm">
               {proposal.description}
             </p>
           )}
+
           <Link
             to={`/proposals/${proposal.id}`}
             className="mt-2 inline-flex text-xs font-medium text-emerald-400 transition-colors hover:text-emerald-300 focus:outline-none focus:ring-2 focus:ring-zinc-400 rounded"
@@ -218,6 +229,7 @@ export function ProposalCard({
             View details
           </Link>
         </div>
+
         <div className="flex items-center gap-2">
           <button
             type="button"
@@ -236,22 +248,30 @@ export function ProposalCard({
               <Link2 size={16} />
             )}
           </button>
-          <span
-            role="note"
-            aria-label={`Category: ${proposal.category}`}
-            className={`text-xs px-2 py-0.5 rounded-full font-mono capitalize ${CATEGORY_STYLES[proposal.category]}`}
-          >
-            {proposal.category}
-          </span>
+          {proposal.category && (
+            <span
+              role="note"
+              aria-label={`Category: ${proposal.category}`}
+              className={`text-xs px-2 py-0.5 rounded-full font-mono capitalize ${
+                CATEGORY_STYLES[proposal.category] ?? "bg-zinc-800 text-zinc-400"
+              }`}
+            >
+              {proposal.category}
+            </span>
+          )}
           <StatusBadge status={proposal.status} />
         </div>
       </div>
 
       <div className="flex items-center justify-between mt-4">
+        {/* ApprovalBar uses the proposal's snapshotted quorumWeight fixed at
+            creation time — not the live totalWeight. This ensures the progress
+            bar reflects the original approval requirement even if owner weights
+            change after the proposal is created. */}
         <ApprovalBar
-          approvals={proposal.approvals}
-          threshold={proposal.threshold}
-          approverAddresses={proposal.approverAddresses}
+          approvalWeight={proposal.approvalWeight ?? 0}
+          quorumWeight={proposal.quorumWeight ?? proposal.threshold}
+          totalWeight={proposal.totalWeight ?? 0}
         />
 
         <div className="flex items-center gap-2">
@@ -261,23 +281,29 @@ export function ProposalCard({
             <button
               type="button"
               onClick={() => onApprove(proposal.id)}
-              aria-label={connected ? `Approve proposal #${proposal.id}` : `Connect and approve proposal #${proposal.id}`}
+              aria-label={
+                connected
+                  ? `Approve proposal #${proposal.id}`
+                  : `Connect and approve proposal #${proposal.id}`
+              }
               className="text-xs bg-emerald-600 hover:bg-emerald-500 text-white px-3 py-1 rounded-lg transition-colors font-medium disabled:opacity-50 focus:ring-2 focus:ring-zinc-400 focus:outline-none"
             >
               {connected ? "Approve" : "Connect & Approve"}
             </button>
           )}
 
-          {connected && proposal.userHasApproved && (proposal.status === "pending" || proposal.status === "ready") && (
-            <button
-              type="button"
-              onClick={() => onRevoke(proposal.id)}
-              aria-label={`Revoke approval for proposal #${proposal.id}`}
-              className="text-xs bg-red-600 hover:bg-red-500 text-white px-3 py-1 rounded-lg transition-colors font-medium disabled:opacity-50 focus:ring-2 focus:ring-zinc-400 focus:outline-none"
-            >
-              Revoke
-            </button>
-          )}
+          {connected &&
+            proposal.userHasApproved &&
+            (proposal.status === "pending" || proposal.status === "ready") && (
+              <button
+                type="button"
+                onClick={() => onRevoke(proposal.id)}
+                aria-label={`Revoke approval for proposal #${proposal.id}`}
+                className="text-xs bg-red-600 hover:bg-red-500 text-white px-3 py-1 rounded-lg transition-colors font-medium disabled:opacity-50 focus:ring-2 focus:ring-zinc-400 focus:outline-none"
+              >
+                Revoke
+              </button>
+            )}
 
           {connected && proposal.status === "ready" && !awaitingConfirmation && (
             <button
@@ -316,4 +342,4 @@ export function ProposalCard({
       </div>
     </div>
   );
-});
+}


### PR DESCRIPTION
…t, disburse_recurring entrypoint, and one-period-per-call catch-up policy

- frontend/src/components/ProposalCard.test.tsx: add four stale-weight tests asserting the UI shows a proposal's originally snapshotted quorumWeight — not the live totalWeight — after owner weights change. Fix change_owner_weight test to use the MemoryRouter-wrapped helper.

- frontend/src/components/ApprovalBar.test.tsx (new): dedicated unit tests for ApprovalBar confirming progress and aria-label are measured against the snapshotted quorumWeight, the quorum tick is positioned against totalWeight, and edge cases (0 quorum, 0 total) are handled.

- frontend/src/components/ProposalCard.tsx: fix ApprovalBar call to pass proposal.approvalWeight / quorumWeight / totalWeight (snapshotted values) instead of the old approvals/threshold/approverAddresses props. Add Link import, CATEGORY_STYLES map, recurring kind entry, and clean up duplicate KindSummary render and stray closing bracket.

- contracts/accord/src/lib.rs: define the missing RecurringPaymentCreatedEvent struct (id, proposer, recipient, token, amount, interval_secs, start_time, end_time, cliff_time, total_cap, kind) that was already emitted on CreateRecurringPayment execution but never declared. Add catch-up policy doc comment to disburse_recurring explaining the one-period-per-call decision and the reasoning for rejecting a batch-all-missed-periods approach.

Closes #415 
Closes #443 
Closes #444 
Closes #445