### PR TITLE
AccordProtocol Issue #413, #414

### DIFF
--- a/frontend/e2e/owners-weight-distribution.spec.ts
+++ b/frontend/e2e/owners-weight-distribution.spec.ts
@@ -1,0 +1,127 @@
+import { Keypair, nativeToScVal, xdr } from "@stellar/stellar-sdk";
+import { expect, test, TEST_WALLET } from "./setup";
+
+const RPC = "https://mock-rpc.test";
+const OWNERS = [
+  "GA37572K2O4WHDGLI2UM4CNTMYZDZI4V5AZL4GJV7AQGR3HMVTVRXDKP",
+  "GCOTL5HEOY6ZC453QWAAIYL2QTZWNXWWU4PF22TK22YBZE6XLBIQHUH2",
+  "GCCZUKX7LI3MSLUA4MIIN3LSO43DTBPJMHBPSTUQISDLMZMPOJU3ANWJ",
+];
+const OWNER_WEIGHTS = [
+  { owner: OWNERS[0], weight: 12 },
+  { owner: OWNERS[1], weight: 7 },
+  { owner: OWNERS[2], weight: 1 },
+];
+
+const accountId = Keypair.fromPublicKey(TEST_WALLET).xdrAccountId();
+const ENTRY_B64 = new xdr.LedgerEntry({
+  lastModifiedLedgerSeq: 100,
+  data: xdr.LedgerEntryData.account(
+    new xdr.AccountEntry({
+      accountId,
+      balance: xdr.Int64.fromString("100000000000"),
+      seqNum: xdr.Int64.fromString("1000000000000"),
+      numSubEntries: 0,
+      inflationDest: null,
+      flags: 0,
+      homeDomain: Buffer.alloc(32),
+      thresholds: Buffer.alloc(4),
+      signers: [],
+      ext: xdr.AccountEntryExt.fromXDR(Buffer.from([0, 0, 0, 0])),
+    }),
+  ),
+  ext: xdr.LedgerEntryExt.fromXDR(Buffer.from([0, 0, 0, 0])),
+}).toXDR("base64");
+const KEY_B64 = xdr.LedgerKey.account(new xdr.LedgerKeyAccount({ accountId })).toXDR("base64");
+const TX_DATA_B64 = new xdr.SorobanTransactionData({
+  ext: xdr.SorobanTransactionDataExt.fromXDR(Buffer.from([0, 0, 0, 0])),
+  resources: new xdr.SorobanResources({
+    footprint: new xdr.LedgerFootprint({ readOnly: [], readWrite: [] }),
+    instructions: 1_000_000,
+    diskReadBytes: 0,
+    writeBytes: 0,
+  }),
+  resourceFee: xdr.Int64.fromString("100"),
+}).toXDR("base64");
+
+function getFunctionName(transaction: string): string {
+  const envelope = xdr.TransactionEnvelope.fromXDR(transaction, "base64");
+  const functionName = envelope
+    .v1()
+    .tx()
+    .operations()[0]
+    .body()
+    .invokeHostFunctionOp()
+    .hostFunction()
+    .invokeContract()
+    .functionName();
+  return Buffer.from(functionName).toString();
+}
+
+function simulationResult(id: unknown, retval: string) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    result: {
+      cost: { cpuInsns: "1000", memBytes: "2000" },
+      results: [{ auth: [], xdr: retval }],
+      minResourceFee: "100",
+      transactionData: TX_DATA_B64,
+      events: [],
+      latestLedger: 1000,
+    },
+  };
+}
+
+test("owners weight distribution chart visual regression", async ({ page }) => {
+  await page.route(`${RPC}/**`, async (route) => {
+    const body = route.request().postDataJSON() as {
+      id: unknown;
+      method: string;
+      params?: { transaction?: string };
+    };
+
+    if (body.method === "getLedgerEntries") {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { entries: [{ key: KEY_B64, xdr: ENTRY_B64, lastModifiedLedgerSeq: 100 }], latestLedger: 1000 },
+        }),
+      });
+      return;
+    }
+
+    if (body.method !== "simulateTransaction") {
+      await route.continue();
+      return;
+    }
+
+    const functionName = getFunctionName(body.params?.transaction ?? "");
+    const resultByFunction: Record<string, string> = {
+      get_owners: xdr.ScVal.scvVec(OWNERS.map((owner) => nativeToScVal(owner, { type: "address" }))).toXDR("base64"),
+      get_threshold: nativeToScVal(15, { type: "u32" }).toXDR("base64"),
+      get_total_proposals: nativeToScVal(0n, { type: "u64" }).toXDR("base64"),
+      get_owner_weights: xdr.ScVal.scvVec(
+        OWNER_WEIGHTS.map(({ owner, weight }) => nativeToScVal({ owner, weight: BigInt(weight) })),
+      ).toXDR("base64"),
+      get_required_quorum_weight: nativeToScVal(15, { type: "u32" }).toXDR("base64"),
+      get_active_delegations: xdr.ScVal.scvVec([]).toXDR("base64"),
+      get_recurring_payments: xdr.ScVal.scvVec([]).toXDR("base64"),
+      is_frozen: xdr.ScVal.scvBool(false).toXDR("base64"),
+      get_spending_limit: nativeToScVal(-1n, { type: "i64" }).toXDR("base64"),
+    };
+
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(simulationResult(body.id, resultByFunction[functionName] ?? xdr.ScVal.scvVoid().toXDR("base64"))),
+    });
+  });
+
+  await page.goto("/app/owners");
+  const chart = page.getByTestId("weight-distribution-chart");
+  await expect(chart).toBeVisible();
+  await expect(chart.getByRole("img")).toHaveCount(3);
+  await expect(chart).toHaveScreenshot("owners-weight-distribution.png");
+});

--- a/frontend/src/components/ApprovalBar.test.tsx
+++ b/frontend/src/components/ApprovalBar.test.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { ApprovalBar } from "./ApprovalBar";
+
+describe("ApprovalBar", () => {
+  test("shows quorum completion for a single owner holding all voting weight", () => {
+    render(
+      <ApprovalBar approvalWeight={100} quorumWeight={100} totalWeight={100} />,
+    );
+
+    expect(screen.getByLabelText(/100 percent of quorum achieved/)).toBeInTheDocument();
+    expect(screen.getByText("100 / 100 weight")).toBeInTheDocument();
+    expect(screen.queryByText(/NaN/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/OwnersPage.test.tsx
+++ b/frontend/src/pages/OwnersPage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { useOwnerWeights } from "../hooks/useOwnerWeights";
 import { getWeightCapPct, getRequiredQuorumWeight, getSpendingLimit } from "../lib/contract";
@@ -10,7 +10,12 @@ vi.mock("../hooks/useOwnerWeights", () => ({
   useOwnerWeights: vi.fn(),
 }));
 
+vi.mock("../lib/submit", () => ({
+  createSpendingLimitProposal: vi.fn(),
+}));
+
 vi.mock("../lib/contract", () => ({
+  getWeightCapPct: vi.fn().mockResolvedValue(50),
   getRequiredQuorumWeight: vi.fn().mockResolvedValue(15),
   getSpendingLimit: vi.fn().mockResolvedValue(-1n),
 }));
@@ -59,8 +64,8 @@ describe("OwnersPage", () => {
       .toBeInTheDocument();
     expect(screen.getAllByText("Signer 1").length).toBeGreaterThan(0);
     expect(screen.getByText(/GOWNER\.\.\.R111/)).toBeInTheDocument();
-    expect(screen.getByText(/Weight 5/)).toBeInTheDocument();
-    expect(screen.getAllByText(/Weight 15/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Raw 5/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Raw 15/).length).toBeGreaterThan(0);
     expect(screen.getByText("25.0% of voting power must approve.")).toBeInTheDocument();
   });
 
@@ -101,5 +106,36 @@ describe("OwnersPage", () => {
     expect(screen.getAllByText("Signer 1").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Signer 2").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Weight unavailable")).toHaveLength(2);
+  });
+
+  test("renders a sole owner's complete voting share and reaches quorum with their approval", async () => {
+    const soleOwnerAddress = "GSOLEOWNER";
+    mockUseOwnerWeights.mockReturnValue({
+      weights: { [soleOwnerAddress]: 100 },
+      totalWeight: 100,
+      loading: false,
+      error: null,
+    });
+    mockGetRequiredQuorumWeight.mockResolvedValue(100);
+
+    render(
+      <OwnersPage
+        owners={[{ address: "GSOLE...WNER", label: "Sole Owner", weight: 100 }]}
+        ownerAddresses={[soleOwnerAddress]}
+        threshold={100}
+        walletAddress={null}
+        onProposalSubmitted={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByText("100.0% of voting power must approve."))
+      .toBeInTheDocument();
+    expect(screen.getAllByText(/100\.0% of voting power/)).toHaveLength(2);
+    expect(screen.getByRole("img", { name: /weight 100 \(100\.0%\)/ })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Sole Owner for quorum simulation" }));
+
+    expect(await screen.findByText("Quorum met")).toBeInTheDocument();
+    expect(screen.queryByText(/NaN/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/OwnersPage.tsx
+++ b/frontend/src/pages/OwnersPage.tsx
@@ -365,7 +365,10 @@ export function OwnersPage({
       </div>
 
       {/* Weight Distribution Chart */}
-      <div className="mb-8 bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+      <div
+        data-testid="weight-distribution-chart"
+        className="mb-8 bg-zinc-900 border border-zinc-800 rounded-xl p-5"
+      >
         <h2 className="text-sm font-medium text-zinc-400 mb-3">
           Voting Weight Distribution
         </h2>


### PR DESCRIPTION
## Summary

Adds frontend regression coverage for weighted governance:

- Adds a seeded Playwright visual regression spec for the Owners page voting-weight distribution chart.
- Adds Vitest coverage for the valid single-owner, 100%-of-total-weight case across OwnersPage and ApprovalBar.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [x] Refactor

## Related Issue

Closes #413  
Closes #414

## Testing Checklist

- [ ] Existing tests pass locally
- [x] New tests added to cover this change (where applicable)
- [x] Manually verified the change works as expected
- [ ] Lint / type checks pass
