### PR TITLE
Allow permissionless cranking of due recurring payments

### DIFF
--- a/contracts/accord/src/lib.rs
+++ b/contracts/accord/src/lib.rs
@@ -1740,6 +1740,12 @@ impl AccordContract {
 
     /// Disburses one due period for a recurring payment schedule.
     ///
+    /// Permissionless crank: any address may trigger this entrypoint once a
+    /// schedule is due. This keeps automation simple and reduces the chance that
+    /// due payouts are missed, at the cost of allowing anyone to trigger the
+    /// transfer path as long as the schedule is eligible and the contract is not
+    /// frozen.
+    ///
     /// Non-retroactive pause/resume policy:
     /// Paused schedules cannot disburse, and `last_disbursed_at` does not advance while paused.
     /// When resumed, the schedule continues from its pre-pause `last_disbursed_at`, requiring
@@ -1751,7 +1757,6 @@ impl AccordContract {
         schedule_id: u64,
     ) -> Result<(), ContractError> {
         caller.require_auth();
-        require_owner(&env, &caller)?;
         require_not_frozen(&env)?;
 
         let mut schedule = read_recurring_payment(&env, schedule_id)?;


### PR DESCRIPTION
closes #449 
## Summary
This PR implements a permissionless execution model for `disburse_recurring`, allowing any address to trigger due payouts on active recurring payment schedules.

Under this model, any caller can execute the disbursement crank once a schedule becomes due, provided the contract is not frozen and the schedule remains eligible for settlement. The restrictive owner-only requirement has been removed while retaining all core safety and freeze validations.

---

## Background & Architectural Trade-offs
The design decision centered on whether recurring disbursement execution should be restricted to contract owners or open as a public keeper crank:

* **Benefits:** A permissionless crank significantly simplifies off-chain automation (e.g., Gelato, Chainlink Keepers, or custom cron bots) and reduces the risk of missed payouts by allowing third parties or beneficiaries to trigger execution directly.
* **Trade-offs:** Opening the entrypoint increases surface area for opportunistic execution or front-running disbursement triggers.

Adopting a permissionless pattern balances high automation reliability with robust contract safety by preserving freeze controls and strict eligibility criteria.

---

## What Changed
* **Access Control Refactor:** Removed the restrictive `require_owner` check from the active `disburse_recurring` entrypoint.
* **Preserved Safety Invariants:** Retained `caller.require_auth()` and the `require_not_frozen(&env)?` state validation.
* **Inline Documentation:** Documented the automation vs. timing trade-offs directly within the function comments.

---

## Why
* **Keeper-Friendly Automation:** Enables third-party bots and decentralized keepers to process due payouts autonomously without privileged keys.
* **High Settlement Reliability:** Prevents disbursement stalls if the owner account is inactive, unavailable, or experiencing operational delays.
* **Strict State Safety:** Maintains invariant guarantees that disbursements cannot occur while the contract is frozen.