### PR TITLE
fix(frontend): add SPA rewrites so client routes deploy on Vercel

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
The app uses BrowserRouter routes (`/app`, `/docs`, `/proposals/:id`), but the Vercel deployment has no SPA fallback, so direct loads and refreshes on those routes return Vercel's `404: NOT_FOUND` page. Adds `frontend/vercel.json` rewriting all paths to `/index.html` (standard Vite SPA deployment config).